### PR TITLE
Refactoring to increase code coverage

### DIFF
--- a/src/bookish_spork_format.erl
+++ b/src/bookish_spork_format.erl
@@ -5,6 +5,49 @@
     reason_phrase/1
 ]).
 
+-define(HTTP_STATUSES, #{
+    100 => <<"Continue">>,
+    101 => <<"Switching Protocols">>,
+    200 => <<"OK">>,
+    201 => <<"Created">>,
+    202 => <<"Accepted">>,
+    203 => <<"Non-Authoritative Information">>,
+    204 => <<"No Content">>,
+    205 => <<"Reset Content">>,
+    206 => <<"Partial Content">>,
+    300 => <<"Multiple Choices">>,
+    301 => <<"Moved Permanently">>,
+    302 => <<"Found">>,
+    303 => <<"See Other">>,
+    304 => <<"Not Modified">>,
+    305 => <<"Use Proxy">>,
+    307 => <<"Temporary Redirect">>,
+    400 => <<"Bad Request">>,
+    401 => <<"Unauthorized">>,
+    402 => <<"Payment Required">>,
+    403 => <<"Forbidden">>,
+    404 => <<"Not Found">>,
+    405 => <<"Method Not Allowed">>,
+    406 => <<"Not Acceptable">>,
+    407 => <<"Proxy Authentication Required">>,
+    408 => <<"Request Time-out">>,
+    409 => <<"Conflict">>,
+    410 => <<"Gone">>,
+    411 => <<"Length Required">>,
+    412 => <<"Precondition Failed">>,
+    413 => <<"Request Entity Too Large">>,
+    414 => <<"Request-URI Too Large">>,
+    415 => <<"Unsupported Media Type">>,
+    416 => <<"Requested range not satisfiable">>,
+    417 => <<"Expectation Failed">>,
+    500 => <<"Internal Server Error">>,
+    501 => <<"Not Implemented">>,
+    502 => <<"Bad Gateway">>,
+    503 => <<"Service Unavailable">>,
+    504 => <<"Gateway Time-out">>,
+    505 => <<"HTTP Version not supported">>
+}).
+
 -spec rfc2616_date(DateTime :: calendar:datetime()) -> binary().
 %% @doc formats date and time for Server header
 rfc2616_date({Date, Time}) ->
@@ -25,70 +68,20 @@ rfc2616_date({Date, Time}) ->
     ]).
 
 -spec reason_phrase(Status :: non_neg_integer()) -> binary().
-reason_phrase(100) -> <<"Continue">>;
-reason_phrase(101) -> <<"Switching Protocols">>;
-reason_phrase(200) -> <<"OK">>;
-reason_phrase(201) -> <<"Created">>;
-reason_phrase(202) -> <<"Accepted">>;
-reason_phrase(203) -> <<"Non-Authoritative Information">>;
-reason_phrase(204) -> <<"No Content">>;
-reason_phrase(205) -> <<"Reset Content">>;
-reason_phrase(206) -> <<"Partial Content">>;
-reason_phrase(300) -> <<"Multiple Choices">>;
-reason_phrase(301) -> <<"Moved Permanently">>;
-reason_phrase(302) -> <<"Found">>;
-reason_phrase(303) -> <<"See Other">>;
-reason_phrase(304) -> <<"Not Modified">>;
-reason_phrase(305) -> <<"Use Proxy">>;
-reason_phrase(307) -> <<"Temporary Redirect">>;
-reason_phrase(400) -> <<"Bad Request">>;
-reason_phrase(401) -> <<"Unauthorized">>;
-reason_phrase(402) -> <<"Payment Required">>;
-reason_phrase(403) -> <<"Forbidden">>;
-reason_phrase(404) -> <<"Not Found">>;
-reason_phrase(405) -> <<"Method Not Allowed">>;
-reason_phrase(406) -> <<"Not Acceptable">>;
-reason_phrase(407) -> <<"Proxy Authentication Required">>;
-reason_phrase(408) -> <<"Request Time-out">>;
-reason_phrase(409) -> <<"Conflict">>;
-reason_phrase(410) -> <<"Gone">>;
-reason_phrase(411) -> <<"Length Required">>;
-reason_phrase(412) -> <<"Precondition Failed">>;
-reason_phrase(413) -> <<"Request Entity Too Large">>;
-reason_phrase(414) -> <<"Request-URI Too Large">>;
-reason_phrase(415) -> <<"Unsupported Media Type">>;
-reason_phrase(416) -> <<"Requested range not satisfiable">>;
-reason_phrase(417) -> <<"Expectation Failed">>;
-reason_phrase(500) -> <<"Internal Server Error">>;
-reason_phrase(501) -> <<"Not Implemented">>;
-reason_phrase(502) -> <<"Bad Gateway">>;
-reason_phrase(503) -> <<"Service Unavailable">>;
-reason_phrase(504) -> <<"Gateway Time-out">>;
-reason_phrase(505) -> <<"HTTP Version not supported">>;
-reason_phrase(_)   -> <<"Unknown">>.
+reason_phrase(Status) ->
+    maps:get(Status, ?HTTP_STATUSES, <<"Unknown">>).
 
 %% @private
-weekday(1) -> <<"Mon">>;
-weekday(2) -> <<"Tue">>;
-weekday(3) -> <<"Wed">>;
-weekday(4) -> <<"Thu">>;
-weekday(5) -> <<"Fri">>;
-weekday(6) -> <<"Sat">>;
-weekday(7) -> <<"Sun">>.
+weekday(DayNum) ->
+    element(DayNum, {<<"Mon">>, <<"Tue">>, <<"Wed">>, <<"Thu">>, <<"Fri">>, <<"Sat">>, <<"Sun">>}).
 
 %% @private
-month(1)  -> <<"Jan">>;
-month(2)  -> <<"Feb">>;
-month(3)  -> <<"Mar">>;
-month(4)  -> <<"Apr">>;
-month(5)  -> <<"May">>;
-month(6)  -> <<"Jun">>;
-month(7)  -> <<"Jul">>;
-month(8)  -> <<"Aug">>;
-month(9)  -> <<"Sep">>;
-month(10) -> <<"Oct">>;
-month(11) -> <<"Nov">>;
-month(12) -> <<"Dec">>.
+month(MonthNum) ->
+    element(MonthNum, {
+        <<"Jan">>, <<"Feb">>, <<"Mar">>, <<"Apr">>,
+        <<"May">>, <<"Jun">>, <<"Jul">>, <<"Aug">>,
+        <<"Sep">>, <<"Oct">>, <<"Nov">>, <<"Dec">>
+    }).
 
 %% @private
 timepad(Int) ->

--- a/src/bookish_spork_request.erl
+++ b/src/bookish_spork_request.erl
@@ -83,7 +83,7 @@ uri(#request{ uri = Uri}) ->
 version(#request{ version = Version }) ->
     Version.
 
--spec header(Request :: request(), HeaderName :: string()) -> binary().
+-spec header(Request :: request(), HeaderName :: string()) -> string() | undefined.
 %% @doc Returns a particular header from request. Header name is lowerced
 header(#request{ headers = Headers }, HeaderName) ->
     maps:get(HeaderName, Headers, undefined).

--- a/src/bookish_spork_request.erl
+++ b/src/bookish_spork_request.erl
@@ -11,6 +11,7 @@
     method/1,
     uri/1,
     version/1,
+    header/2,
     headers/1,
     body/1,
     body/2
@@ -59,8 +60,8 @@ add_header(#request{ headers = Headers } = Request, Name, Value) ->
 
 -spec content_length(Request :: request()) -> integer().
 %% @doc Content-Length header value as intger
-content_length(#request{ headers = Headers }) ->
-    case maps:get("content-length", Headers, undefined) of
+content_length(Request) ->
+    case header(Request, "content-length") of
         undefined ->
             0;
         ContentLength ->
@@ -69,24 +70,35 @@ content_length(#request{ headers = Headers }) ->
 
 -spec method(Request :: request()) -> atom().
 %% @doc http verb: 'GET', 'POST','PUT', 'DELETE', 'OPTIONS', ...
-method(#request{ method = Method}) -> Method.
+method(#request{ method = Method}) ->
+    Method.
 
 -spec uri(Request :: request()) -> string().
 %% @doc path with query string
-uri(#request{ uri = Uri}) -> Uri.
+uri(#request{ uri = Uri}) ->
+    Uri.
 
 -spec version(Request :: request()) -> string() | undefined.
 %% @doc http protocol version tuple. Most often would be {1, 1}
-version(#request{ version = Version }) -> Version.
+version(#request{ version = Version }) ->
+    Version.
+
+-spec header(Request :: request(), HeaderName :: string()) -> binary().
+%% @doc Returns a particular header from request. Header name is lowerced
+header(#request{ headers = Headers }, HeaderName) ->
+    maps:get(HeaderName, Headers, undefined).
 
 -spec headers(Request :: request()) -> map().
 %% @doc http headers map. Header names are normalized and lowercased
-headers(#request{ headers = Headers }) -> Headers.
+headers(#request{ headers = Headers }) ->
+    Headers.
 
 -spec body(Request :: request()) -> binary().
 %% @doc request body
-body(#request{ body = Body }) -> Body.
+body(#request{ body = Body }) ->
+    Body.
 
 -spec body(Request :: request(), Body :: binary()) -> request().
 %% @private
-body(Request, Body) -> Request#request{ body = Body }.
+body(Request, Body) ->
+    Request#request{ body = Body }.

--- a/src/bookish_spork_response.erl
+++ b/src/bookish_spork_response.erl
@@ -75,13 +75,9 @@ status_line(Status) ->
 
 %% @private
 headers(ExtraHeaders, Content) ->
-    headers(ExtraHeaders, Content, calendar:universal_time()).
-
-%% @private
-headers(ExtraHeaders, Content, Now) ->
     Headers = maps:merge(#{
         <<"Server">> => ?DEFAULT_SERVER,
-        <<"Date">> => bookish_spork_format:rfc2616_date(Now),
+        <<"Date">> => bookish_spork_format:rfc2616_date(utc_now()),
         <<"Content-Length">> => list_to_binary(integer_to_list(size(Content)))
     }, ExtraHeaders),
     maps:fold(fun(K, V, Acc) ->
@@ -91,3 +87,13 @@ headers(ExtraHeaders, Content, Now) ->
             V/binary, ?CRLF
         >>
     end, <<>>, Headers).
+
+-ifdef(TEST).
+%% @private
+utc_now() ->
+    {{2018, 4, 28}, {5, 51, 50}}.
+-else.
+%% @private
+utc_now() ->
+    calendar:universal_time().
+-endif.

--- a/test/bookish_spork_SUITE.erl
+++ b/test/bookish_spork_SUITE.erl
@@ -3,42 +3,38 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--define(T, bookish_spork).
-
 -export([
     all/0
 ]).
 -export([
     base_integration_test/1,
-    customized_response_test/1
+    customized_response_test/1,
+    failed_capture_test/1,
+    stub_multiple_requests_test/1
 ]).
 
 all() ->
-    [base_integration_test, customized_response_test].
+    [base_integration_test, customized_response_test,
+    failed_capture_test, stub_multiple_requests_test].
 
 base_integration_test(_Config) ->
-    {ok, _Pid} = ?T:start_server(),
-    {ok, _Acceptor} = ?T:stub_request(),
-
+    {ok, _Pid} = bookish_spork:start_server(),
+    {ok, _Acceptor} = bookish_spork:stub_request(),
     RequestHeaders = [],
     {ok, {{"HTTP/1.1", 204, "No Content"}, _ResponseHeaders, _Body}} =
       httpc:request(get, {"http://localhost:32002/o/lo/lo?q=kjk", RequestHeaders}, [], []),
-
-    {ok, Request} = ?T:capture_request(),
+    {ok, Request} = bookish_spork:capture_request(),
     ?assertEqual('GET', bookish_spork_request:method(Request)),
     ?assertEqual("/o/lo/lo?q=kjk", bookish_spork_request:uri(Request)),
     ?assertEqual({1, 1}, bookish_spork_request:version(Request)),
     ?assertMatch(#{"host" := "localhost:32002"}, bookish_spork_request:headers(Request)),
-    ok = ?T:stop_server().
-
-
+    ok = bookish_spork:stop_server().
 
 customized_response_test(_Config) ->
-    {ok, _Pid} = ?T:start_server(9871),
-    ?T:stub_request(200,
+    {ok, _Pid} = bookish_spork:start_server(9871),
+    bookish_spork:stub_request(200,
         #{<<"X-Custom-Response-Header">> => <<"test">>},
         <<"Hello, Test">>),
-
     RequestBody = <<"{\"name\": \"John Doe\", \"email\": \"john@doe.com\"}">>,
     {ok, {{"HTTP/1.1", 200, "OK"}, ResponseHeaders, Body}} = httpc:request(post, {
         "http://localhost:9871/api/v1/users",
@@ -46,15 +42,39 @@ customized_response_test(_Config) ->
         "application/json",
         RequestBody
     }, [], [{body_format, binary}]),
-    ?assertEqual({"x-custom-response-header", "test"},
-        proplists:lookup("x-custom-response-header", ResponseHeaders)),
+    ?assertEqual("test", proplists:get_value("x-custom-response-header", ResponseHeaders)),
     ?assertEqual(<<"Hello, Test">>, string:chomp(Body)),
-
-    {ok, Request} = ?T:capture_request(),
+    {ok, Request} = bookish_spork:capture_request(),
     ?assertEqual('POST', bookish_spork_request:method(Request)),
     ?assertEqual("/api/v1/users", bookish_spork_request:uri(Request)),
     ?assertEqual({1, 1}, bookish_spork_request:version(Request)),
     ?assertEqual(RequestBody, bookish_spork_request:body(Request)),
     ?assertMatch(#{"accept" := "text/plain"}, bookish_spork_request:headers(Request)),
+    ok = bookish_spork:stop_server().
 
-    ok = ?T:stop_server().
+failed_capture_test(_Config) ->
+    {ok, _Pid} = bookish_spork:start_server(),
+    ?assertEqual(timeout, bookish_spork:capture_request(), "Got timeout when there is no stub"),
+    ok = bookish_spork:stop_server().
+
+stub_multiple_requests_test(_Config) ->
+    {ok, _Pid} = bookish_spork:start_server(),
+    bookish_spork:stub_request(200, #{<<"X-Number">> => <<"The First">>}),
+    bookish_spork:stub_request(200, <<"The second">>),
+    bookish_spork:stub_request(202),
+    {ok, {{"HTTP/1.1", 200, "OK"}, Headers1, Body1}} = httpc:request(get,
+        {"http://localhost:32002/first/request", []}, [], [{body_format, binary}]),
+    {ok, {{"HTTP/1.1", 200, "OK"}, _Headers, Body2}} = httpc:request(get,
+        {"http://localhost:32002/second/request", []}, [], [{body_format, binary}]),
+    {ok, {{"HTTP/1.1", 202, "Accepted"}, _, _}} = httpc:request(get,
+        {"http://localhost:32002/third/request", []}, [], [{body_format, binary}]),
+    ?assertEqual("The First", proplists:get_value("x-number", Headers1)),
+    ?assertEqual(<<>>, Body1),
+    ?assertEqual(<<"The second">>, Body2),
+    {ok, Request1} = bookish_spork:capture_request(),
+    {ok, Request2} = bookish_spork:capture_request(),
+    {ok, Request3} = bookish_spork:capture_request(),
+    ?assertEqual("/first/request", bookish_spork_request:uri(Request1)),
+    ?assertEqual("/second/request", bookish_spork_request:uri(Request2)),
+    ?assertEqual("/third/request", bookish_spork_request:uri(Request3)),
+    ok = bookish_spork:stop_server().

--- a/test/bookish_spork_response_test.erl
+++ b/test/bookish_spork_response_test.erl
@@ -1,14 +1,11 @@
 -module(bookish_spork_response_test).
 -include_lib("eunit/include/eunit.hrl").
 
--define(T, bookish_spork_response).
--define(NOW, {{2018, 4, 28}, {5, 51, 50}}).
-
 status_line_test() ->
-    ?assertEqual(<<"HTTP/1.1 204 No Content">>, ?T:status_line(204)).
+    ?assertEqual(<<"HTTP/1.1 204 No Content">>, bookish_spork_response:status_line(204)).
 
 response_headers_test() ->
-    Actual = ?T:headers(#{}, <<"XXX">>, ?NOW),
+    Actual = bookish_spork_response:headers(#{}, <<"XXX">>),
     Expected = <<
         "Content-Length: 3\r\n",
         "Date: Sat, 28 Apr 2018 05:51:50 GMT\r\n",
@@ -16,19 +13,52 @@ response_headers_test() ->
     >>,
     ?assertEqual(Expected, Actual).
 
-write_str_test() ->
-    Response = ?T:new(200, #{
-        <<"Content-Type">> => <<"text/plain">>,
-        <<"Date">> => <<"Tue, 12 Jun 2018 14:12:37 GMT">>
-    }, <<"Hello">>),
-    Expected = <<
-        "HTTP/1.1 200 OK\r\n",
-        "Content-Length: 5\r\n",
-        "Content-Type: text/plain\r\n",
-        "Date: Tue, 12 Jun 2018 14:12:37 GMT\r\n",
-        "Server: BookishSpork/0.0.1\r\n"
-        "\r\n",
-        "Hello"
-    >>,
-    Actual = ?T:write_str(Response),
-    ?assertEqual(Expected, Actual).
+write_str_test_() ->
+    DefaultResponse = bookish_spork_response:new(),
+    CustomsStatus = bookish_spork_response:new(502),
+    CustomsStatusAndContent = bookish_spork_response:new(409, <<"Booookish">>),
+    CustomsStatusAndHeaders = bookish_spork_response:new(307,
+        #{<<"Location">> => <<"https://example.com">>}),
+    CustomResponse = bookish_spork_response:new(200,
+        #{<<"Content-Type">> => <<"text/plain">>}, <<"Hello">>),
+    [
+        ?_assertEqual(<<
+            "HTTP/1.1 204 No Content\r\n",
+            "Content-Length: 0\r\n",
+            "Date: Sat, 28 Apr 2018 05:51:50 GMT\r\n",
+            "Server: BookishSpork/0.0.1\r\n",
+            "\r\n"
+        >>, bookish_spork_response:write_str(DefaultResponse)),
+        ?_assertEqual(<<
+            "HTTP/1.1 502 Bad Gateway\r\n",
+            "Content-Length: 0\r\n",
+            "Date: Sat, 28 Apr 2018 05:51:50 GMT\r\n",
+            "Server: BookishSpork/0.0.1\r\n"
+            "\r\n"
+        >>, bookish_spork_response:write_str(CustomsStatus)),
+        ?_assertEqual(<<
+            "HTTP/1.1 409 Conflict\r\n",
+            "Content-Length: 9\r\n",
+            "Date: Sat, 28 Apr 2018 05:51:50 GMT\r\n",
+            "Server: BookishSpork/0.0.1\r\n"
+            "\r\n",
+            "Booookish"
+        >>, bookish_spork_response:write_str(CustomsStatusAndContent)),
+        ?_assertEqual(<<
+            "HTTP/1.1 307 Temporary Redirect\r\n",
+            "Content-Length: 0\r\n",
+            "Date: Sat, 28 Apr 2018 05:51:50 GMT\r\n",
+            "Location: https://example.com\r\n"
+            "Server: BookishSpork/0.0.1\r\n"
+            "\r\n"
+        >>, bookish_spork_response:write_str(CustomsStatusAndHeaders)),
+        ?_assertEqual(<<
+            "HTTP/1.1 200 OK\r\n",
+            "Content-Length: 5\r\n",
+            "Content-Type: text/plain\r\n",
+            "Date: Sat, 28 Apr 2018 05:51:50 GMT\r\n",
+            "Server: BookishSpork/0.0.1\r\n"
+            "\r\n",
+            "Hello"
+        >>, bookish_spork_response:write_str(CustomResponse))
+    ].


### PR DESCRIPTION
- convert pattern-matching to picking from data structures
- add `bookish_spork_request:header/2` fun for one header extraction
- separate versions of `utc_now/0` func for tests 🤢 