### PR TITLE
Adds shields to hexdocs edoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,14 @@ An erlang library to test http requests. Inspired by Ruby's [WebMock](https://gi
 
 Suitable for Elixir.
 
-[![Build Status](https://travis-ci.org/tank-bohr/bookish_spork.svg?branch=master)](https://travis-ci.org/tank-bohr/bookish_spork)
-[![Coverage Status](https://coveralls.io/repos/github/tank-bohr/bookish_spork/badge.svg?branch=master)](https://coveralls.io/github/tank-bohr/bookish_spork?branch=master)
-[![Hex.pm](https://img.shields.io/hexpm/v/bookish_spork.svg)](https://hex.pm/packages/bookish_spork)
-[![Gitter](https://badges.gitter.im/join.svg)](https://gitter.im/bookish_spork)
+[![Build Status](https://travis-ci.org/tank-bohr/bookish_spork.svg?branch=master)
+](https://travis-ci.org/tank-bohr/bookish_spork)
+[![Coverage Status](https://coveralls.io/repos/github/tank-bohr/bookish_spork/badge.svg?branch=master)
+](https://coveralls.io/github/tank-bohr/bookish_spork?branch=master)
+[![Hex.pm](https://img.shields.io/hexpm/v/bookish_spork.svg)
+](https://hex.pm/packages/bookish_spork)
+[![Gitter](https://badges.gitter.im/join.svg)
+](https://gitter.im/bookish_spork)
 
 
 ### <a name="Rationale">Rationale</a> ###

--- a/doc/README.md
+++ b/doc/README.md
@@ -12,10 +12,14 @@ An erlang library to test http requests. Inspired by Ruby's [WebMock](https://gi
 
 Suitable for Elixir.
 
-[![Build Status](https://travis-ci.org/tank-bohr/bookish_spork.svg?branch=master)](https://travis-ci.org/tank-bohr/bookish_spork)
-[![Coverage Status](https://coveralls.io/repos/github/tank-bohr/bookish_spork/badge.svg?branch=master)](https://coveralls.io/github/tank-bohr/bookish_spork?branch=master)
-[![Hex.pm](https://img.shields.io/hexpm/v/bookish_spork.svg)](https://hex.pm/packages/bookish_spork)
-[![Gitter](https://badges.gitter.im/join.svg)](https://gitter.im/bookish_spork)
+[![Build Status](https://travis-ci.org/tank-bohr/bookish_spork.svg?branch=master)
+](https://travis-ci.org/tank-bohr/bookish_spork)
+[![Coverage Status](https://coveralls.io/repos/github/tank-bohr/bookish_spork/badge.svg?branch=master)
+](https://coveralls.io/github/tank-bohr/bookish_spork?branch=master)
+[![Hex.pm](https://img.shields.io/hexpm/v/bookish_spork.svg)
+](https://hex.pm/packages/bookish_spork)
+[![Gitter](https://badges.gitter.im/join.svg)
+](https://gitter.im/bookish_spork)
 
 
 ### <a name="Rationale">Rationale</a> ###

--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -13,7 +13,20 @@ An erlang library to test http requests. Inspired by Ruby's <a target="_blank" h
 
 Suitable for Elixir.
 
-{@shields}
+<a target="_blank" href="https://travis-ci.org/tank-bohr/bookish_spork">
+  <img alt="Build Status" src="https://travis-ci.org/tank-bohr/bookish_spork.svg?branch=master"/>
+</a>
+<a target="_blank" href="https://coveralls.io/github/tank-bohr/bookish_spork?branch=master">
+  <img alt="Coverage Status"
+       src="https://coveralls.io/repos/github/tank-bohr/bookish_spork/badge.svg?branch=master"
+  />
+</a>
+<a target="_blank" href="https://hex.pm/packages/bookish_spork">
+  <img alt="Hex.pm" src="https://img.shields.io/hexpm/v/bookish_spork.svg"/>
+</a>
+<a target="_blank" href="https://gitter.im/bookish_spork">
+  <img alt="Gitter" src="https://badges.gitter.im/join.svg"/>
+</a>
 
 == Rationale ==
 

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -7,29 +7,18 @@ Config1 = case os:getenv("TRAVIS") of
         CONFIG
 end,
 
-%% Add shields to edown
-{ok, ShieldsBinary} = file:read_file("shields.md"),
-Shields = binary_to_list(ShieldsBinary),
-{profiles, Profiles0} = lists:keyfind(profiles, 1, Config1),
-{edown, EdownProfile0} = lists:keyfind(edown, 1, Profiles0),
-{edoc_opts, EdownEdocOpts0} = lists:keyfind(edoc_opts, 1, EdownProfile0),
-EdownEdocOpts1 = [{def, {shields, Shields}} | EdownEdocOpts0],
-EdownProfile1 = lists:keyreplace(edoc_opts, 1, EdownProfile0, {edoc_opts, EdownEdocOpts1}),
-Profiles1 = lists:keyreplace(edown, 1, Profiles0, {edown, EdownProfile1}),
-Config2 = lists:keyreplace(profiles, 1, Config1, {profiles, Profiles1}),
-
 %% Add year to Copyright
 {{Year, _, _}, _} = calendar:universal_time(),
-{edoc_opts, EdocOpts0} = lists:keyfind(edoc_opts, 1, Config2),
+{edoc_opts, EdocOpts0} = lists:keyfind(edoc_opts, 1, Config1),
 EdocOpts1 = [{def, {year, integer_to_list(Year)}} | EdocOpts0],
-Config3 = lists:keyreplace(edoc_opts, 1, Config2, {edoc_opts, EdocOpts1}),
+Config2 = lists:keyreplace(edoc_opts, 1, Config1, {edoc_opts, EdocOpts1}),
 
 %% Add version number for edoc
 case os:cmd("git tag | tail -1") of
     [$v | Version0] ->
         Version = string:trim(Version0, both, "\n"),
         EdocOpts2 = [{def, {version, Version}} | EdocOpts1],
-        lists:keyreplace(edoc_opts, 1, Config3, {edoc_opts, EdocOpts2});
+        lists:keyreplace(edoc_opts, 1, Config2, {edoc_opts, EdocOpts2});
     _ ->
-        Config3
+        Config2
 end.

--- a/shields.md
+++ b/shields.md
@@ -1,4 +1,0 @@
-[![Build Status](https://travis-ci.org/tank-bohr/bookish_spork.svg?branch=master)](https://travis-ci.org/tank-bohr/bookish_spork)
-[![Coverage Status](https://coveralls.io/repos/github/tank-bohr/bookish_spork/badge.svg?branch=master)](https://coveralls.io/github/tank-bohr/bookish_spork?branch=master)
-[![Hex.pm](https://img.shields.io/hexpm/v/bookish_spork.svg)](https://hex.pm/packages/bookish_spork)
-[![Gitter](https://badges.gitter.im/join.svg)](https://gitter.im/bookish_spork)


### PR DESCRIPTION
Changes:
- Move shields to `overview.edoc` as plain html
- Get rid of shields macros
- Get rid of shields.md markdown file as well

Rationale:
- hexdocs deserves badges too
