### PR TITLE
Data driven

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,13 +100,13 @@ As usual the main goal is to test that you send the correct request
 
 It returns you an opaque structure of the request. You can inspect it with
 
-- [`bookish_spork_request:method/1`](http://github.com/tank-bohr/bookish_spork/blob/master/doc/bookish_spork_request.md#method-1)
+- [`bookish_spork_request:method/1`](http://github.com/tank-bohr/bookish_spork/blob/data-driven/doc/bookish_spork_request.md#method-1)
 
-- [`bookish_spork_request:uri/1`](http://github.com/tank-bohr/bookish_spork/blob/master/doc/bookish_spork_request.md#uri-1)
+- [`bookish_spork_request:uri/1`](http://github.com/tank-bohr/bookish_spork/blob/data-driven/doc/bookish_spork_request.md#uri-1)
 
-- [`bookish_spork_request:headers/1`](http://github.com/tank-bohr/bookish_spork/blob/master/doc/bookish_spork_request.md#headers-1)
+- [`bookish_spork_request:headers/1`](http://github.com/tank-bohr/bookish_spork/blob/data-driven/doc/bookish_spork_request.md#headers-1)
 
-- [`bookish_spork_request:body/1`](http://github.com/tank-bohr/bookish_spork/blob/master/doc/bookish_spork_request.md#body-1)
+- [`bookish_spork_request:body/1`](http://github.com/tank-bohr/bookish_spork/blob/data-driven/doc/bookish_spork_request.md#body-1)
 
 
 #### <a name="Bypass_comparision">Bypass comparision</a> ####
@@ -189,9 +189,9 @@ end
 
 ```
 
-[Module to work with request](http://github.com/tank-bohr/bookish_spork/blob/master/doc/bookish_spork_request.md)
+[Module to work with request](http://github.com/tank-bohr/bookish_spork/blob/data-driven/doc/bookish_spork_request.md)
 
-[Module to work with response](http://github.com/tank-bohr/bookish_spork/blob/master/doc/bookish_spork_response.md)
+[Module to work with response](http://github.com/tank-bohr/bookish_spork/blob/data-driven/doc/bookish_spork_response.md)
 
 <h5><a name="Elixir_example">Elixir example</a></h5>
 
@@ -225,9 +225,9 @@ For more details see examples dir.
 
 
 <table width="100%" border="0" summary="list of modules">
-<tr><td><a href="http://github.com/tank-bohr/bookish_spork/blob/master/doc/bookish_spork.md" class="module">bookish_spork</a></td></tr>
-<tr><td><a href="http://github.com/tank-bohr/bookish_spork/blob/master/doc/bookish_spork_format.md" class="module">bookish_spork_format</a></td></tr>
-<tr><td><a href="http://github.com/tank-bohr/bookish_spork/blob/master/doc/bookish_spork_request.md" class="module">bookish_spork_request</a></td></tr>
-<tr><td><a href="http://github.com/tank-bohr/bookish_spork/blob/master/doc/bookish_spork_response.md" class="module">bookish_spork_response</a></td></tr>
-<tr><td><a href="http://github.com/tank-bohr/bookish_spork/blob/master/doc/bookish_spork_server.md" class="module">bookish_spork_server</a></td></tr></table>
+<tr><td><a href="http://github.com/tank-bohr/bookish_spork/blob/data-driven/doc/bookish_spork.md" class="module">bookish_spork</a></td></tr>
+<tr><td><a href="http://github.com/tank-bohr/bookish_spork/blob/data-driven/doc/bookish_spork_format.md" class="module">bookish_spork_format</a></td></tr>
+<tr><td><a href="http://github.com/tank-bohr/bookish_spork/blob/data-driven/doc/bookish_spork_request.md" class="module">bookish_spork_request</a></td></tr>
+<tr><td><a href="http://github.com/tank-bohr/bookish_spork/blob/data-driven/doc/bookish_spork_response.md" class="module">bookish_spork_response</a></td></tr>
+<tr><td><a href="http://github.com/tank-bohr/bookish_spork/blob/data-driven/doc/bookish_spork_server.md" class="module">bookish_spork_server</a></td></tr></table>
 

--- a/doc/bookish_spork.md
+++ b/doc/bookish_spork.md
@@ -106,7 +106,7 @@ stub_request(Fun::function() | <a href="#type-http_status">http_status()</a>) -&
 
 stub request with fun or particular status
 
-Fun must be <code>fun((<a href="bookish_spork_request.md#type-request">bookish_spork_request:request()</a>) -> <a href="bookish_spork_response.md#type-response">bookish_spork_response:response()</a>)</code>
+Fun must be <code>fun((<a href="bookish_spork_request.md#type-t">bookish_spork_request:t()</a>) -> <a href="bookish_spork_response.md#type-t">bookish_spork_response:t()</a>)</code>
 
 Example:
 

--- a/doc/bookish_spork.md
+++ b/doc/bookish_spork.md
@@ -27,6 +27,16 @@ It provides basic functions for using library
 http_status() = non_neg_integer()
 </code></pre>
 
+
+
+
+### <a name="type-stub_request_fun">stub_request_fun()</a> ###
+
+
+<pre><code>
+stub_request_fun() = fun((<a href="bookish_spork_request.md#type-t">bookish_spork_request:t()</a>) -&gt; <a href="bookish_spork_response.md#type-response">bookish_spork_response:response()</a>)
+</code></pre>
+
 <a name="index"></a>
 
 ## Function Index ##
@@ -100,23 +110,23 @@ Equivalent to [`stub_request(204,#{<<"Server">> => <<"BookishSpork/0.0.1">>,<<"D
 ### stub_request/1 ###
 
 <pre><code>
-stub_request(Fun::function() | <a href="#type-http_status">http_status()</a>) -&gt; ok
+stub_request(Fun::<a href="#type-stub_request_fun">stub_request_fun()</a> | <a href="bookish_spork_response.md#type-response">bookish_spork_response:response()</a>) -&gt; ok
 </code></pre>
 <br />
 
 stub request with fun or particular status
 
-Fun must be <code>fun((<a href="bookish_spork_request.md#type-t">bookish_spork_request:t()</a>) -> <a href="bookish_spork_response.md#type-t">bookish_spork_response:t()</a>)</code>
+Fun must be <code>fun((<a href="bookish_spork_request.md#type-t">bookish_spork_request:t()</a>) -> <a href="bookish_spork_response.md#type-response">bookish_spork_response:response()</a>)</code>
 
 Example:
 
 ```
-  stub_request(fun(Request) ->
+  bookish_spork:stub_request(fun(Request) ->
       case bookish_spork_request:uri(Request) of
           "/bookish/spork" ->
-              bookish_spork_response:new(200, <<"Hello">>);
+              [200, [], <<"Hello">>];
           "/admin/sporks" ->
-              bookish_spork_response:new(403, <<"It is not possible here">>)
+              [403, [], <<"It is not possible here">>]
       end
   end)
 ```
@@ -138,7 +148,7 @@ stub request with particular status and content/headers
 ### stub_request/3 ###
 
 <pre><code>
-stub_request(Status::<a href="#type-http_status">http_status()</a>, Headers::map(), Content::binary()) -&gt; ok
+stub_request(Status::<a href="#type-http_status">http_status()</a>, Headers::map() | list(), Content::binary()) -&gt; ok
 </code></pre>
 <br />
 

--- a/doc/bookish_spork_request.md
+++ b/doc/bookish_spork_request.md
@@ -12,10 +12,10 @@
 
 
 
-### <a name="type-request">request()</a> ###
+### <a name="type-t">t()</a> ###
 
 
-__abstract datatype__: `request()`
+__abstract datatype__: `t()`
 
 <a name="index"></a>
 
@@ -34,7 +34,7 @@ __abstract datatype__: `request()`
 ### body/1 ###
 
 <pre><code>
-body(Request::<a href="#type-request">request()</a>) -&gt; binary()
+body(Request::<a href="#type-t">t()</a>) -&gt; binary()
 </code></pre>
 <br />
 
@@ -45,7 +45,7 @@ request body
 ### content_length/1 ###
 
 <pre><code>
-content_length(Request::<a href="#type-request">request()</a>) -&gt; integer()
+content_length(Request::<a href="#type-t">t()</a>) -&gt; integer()
 </code></pre>
 <br />
 
@@ -56,7 +56,7 @@ Content-Length header value as intger
 ### header/2 ###
 
 <pre><code>
-header(Request::<a href="#type-request">request()</a>, HeaderName::string()) -&gt; string() | undefined
+header(Request::<a href="#type-t">t()</a>, HeaderName::string()) -&gt; string() | undefined
 </code></pre>
 <br />
 
@@ -67,7 +67,7 @@ Returns a particular header from request. Header name is lowerced
 ### headers/1 ###
 
 <pre><code>
-headers(Request::<a href="#type-request">request()</a>) -&gt; map()
+headers(Request::<a href="#type-t">t()</a>) -&gt; map()
 </code></pre>
 <br />
 
@@ -78,7 +78,7 @@ http headers map. Header names are normalized and lowercased
 ### is_keepalive/1 ###
 
 <pre><code>
-is_keepalive(Request::<a href="#type-request">request()</a>) -&gt; boolean()
+is_keepalive(Request::<a href="#type-t">t()</a>) -&gt; boolean()
 </code></pre>
 <br />
 
@@ -89,7 +89,7 @@ tells you if the request is keepalive or not [`https://tools.ietf.org/html/rfc62
 ### method/1 ###
 
 <pre><code>
-method(Request::<a href="#type-request">request()</a>) -&gt; atom()
+method(Request::<a href="#type-t">t()</a>) -&gt; atom()
 </code></pre>
 <br />
 
@@ -100,7 +100,7 @@ http verb: 'GET', 'POST','PUT', 'DELETE', 'OPTIONS', ...
 ### uri/1 ###
 
 <pre><code>
-uri(Request::<a href="#type-request">request()</a>) -&gt; string()
+uri(Request::<a href="#type-t">t()</a>) -&gt; string()
 </code></pre>
 <br />
 
@@ -111,7 +111,7 @@ path with query string
 ### version/1 ###
 
 <pre><code>
-version(Request::<a href="#type-request">request()</a>) -&gt; string() | undefined
+version(Request::<a href="#type-t">t()</a>) -&gt; string() | undefined
 </code></pre>
 <br />
 

--- a/doc/bookish_spork_request.md
+++ b/doc/bookish_spork_request.md
@@ -115,5 +115,5 @@ version(Request::<a href="#type-t">t()</a>) -&gt; string() | undefined
 </code></pre>
 <br />
 
-http protocol version tuple. Most often would be {1, 1}
+http protocol version tuple. Most often would be `{1, 1}`
 

--- a/doc/bookish_spork_response.md
+++ b/doc/bookish_spork_response.md
@@ -12,6 +12,16 @@
 
 
 
+### <a name="type-response">response()</a> ###
+
+
+<pre><code>
+response() = <a href="#type-t">t()</a> | non_neg_integer() | {non_neg_integer(), map(), binary()} | {non_neg_integer(), list(), binary()} | nonempty_list()
+</code></pre>
+
+
+
+
 ### <a name="type-t">t()</a> ###
 
 
@@ -22,7 +32,7 @@ __abstract datatype__: `t()`
 ## Function Index ##
 
 
-<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#new-0">new/0</a></td><td></td></tr><tr><td valign="top"><a href="#new-1">new/1</a></td><td></td></tr><tr><td valign="top"><a href="#new-2">new/2</a></td><td></td></tr><tr><td valign="top"><a href="#new-3">new/3</a></td><td></td></tr><tr><td valign="top"><a href="#write_str-2">write_str/2</a></td><td></td></tr></table>
+<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#new-0">new/0</a></td><td></td></tr><tr><td valign="top"><a href="#new-1">new/1</a></td><td>Constructs a response data structure.</td></tr><tr><td valign="top"><a href="#new-2">new/2</a></td><td></td></tr><tr><td valign="top"><a href="#write_str-2">write_str/2</a></td><td></td></tr></table>
 
 
 <a name="functions"></a>
@@ -43,9 +53,30 @@ new() -&gt; <a href="#type-t">t()</a>
 ### new/1 ###
 
 <pre><code>
-new(Status::non_neg_integer()) -&gt; <a href="#type-t">t()</a>
+new(Response::<a href="#type-response">response()</a>) -&gt; <a href="#type-t">t()</a>
 </code></pre>
 <br />
+
+Constructs a response data structure
+
+Arg can be one of
+
+* Http status code [`https://tools.ietf.org/html/rfc2616#section-6.1.1`](https://tools.ietf.org.md/rfc2616#section-6.1.1)
+
+* Response tuple `{Status, Headers, Body}`
+
+* Response list `[Status, Headers, Body]`
+
+* Response record. Then returns itself
+
+
+Headers may be map or proplist
+
+Example:
+
+```
+  bookish_spork_response:new([200, #{}, <<"Hello">>])
+```
 
 <a name="new-2"></a>
 
@@ -53,15 +84,6 @@ new(Status::non_neg_integer()) -&gt; <a href="#type-t">t()</a>
 
 <pre><code>
 new(Status::non_neg_integer(), ContentOrHeaders::binary() | map()) -&gt; <a href="#type-t">t()</a>
-</code></pre>
-<br />
-
-<a name="new-3"></a>
-
-### new/3 ###
-
-<pre><code>
-new(Status::non_neg_integer(), Headers::map(), Content::binary()) -&gt; <a href="#type-t">t()</a>
 </code></pre>
 <br />
 

--- a/doc/bookish_spork_response.md
+++ b/doc/bookish_spork_response.md
@@ -12,10 +12,10 @@
 
 
 
-### <a name="type-response">response()</a> ###
+### <a name="type-t">t()</a> ###
 
 
-__abstract datatype__: `response()`
+__abstract datatype__: `t()`
 
 <a name="index"></a>
 
@@ -34,7 +34,7 @@ __abstract datatype__: `response()`
 ### new/0 ###
 
 <pre><code>
-new() -&gt; <a href="#type-response">response()</a>
+new() -&gt; <a href="#type-t">t()</a>
 </code></pre>
 <br />
 
@@ -43,7 +43,7 @@ new() -&gt; <a href="#type-response">response()</a>
 ### new/1 ###
 
 <pre><code>
-new(Status::non_neg_integer()) -&gt; <a href="#type-response">response()</a>
+new(Status::non_neg_integer()) -&gt; <a href="#type-t">t()</a>
 </code></pre>
 <br />
 
@@ -52,7 +52,7 @@ new(Status::non_neg_integer()) -&gt; <a href="#type-response">response()</a>
 ### new/2 ###
 
 <pre><code>
-new(Status::non_neg_integer(), ContentOrHeaders::binary() | map()) -&gt; <a href="#type-response">response()</a>
+new(Status::non_neg_integer(), ContentOrHeaders::binary() | map()) -&gt; <a href="#type-t">t()</a>
 </code></pre>
 <br />
 
@@ -61,7 +61,7 @@ new(Status::non_neg_integer(), ContentOrHeaders::binary() | map()) -&gt; <a href
 ### new/3 ###
 
 <pre><code>
-new(Status::non_neg_integer(), Headers::map(), Content::binary()) -&gt; <a href="#type-response">response()</a>
+new(Status::non_neg_integer(), Headers::map(), Content::binary()) -&gt; <a href="#type-t">t()</a>
 </code></pre>
 <br />
 
@@ -70,7 +70,7 @@ new(Status::non_neg_integer(), Headers::map(), Content::binary()) -&gt; <a href=
 ### write_str/2 ###
 
 <pre><code>
-write_str(Response::<a href="#type-response">response()</a>, Now::<a href="calendar.md#type-datetime">calendar:datetime()</a>) -&gt; binary()
+write_str(Response::<a href="#type-t">t()</a>, Now::<a href="calendar.md#type-datetime">calendar:datetime()</a>) -&gt; binary()
 </code></pre>
 <br />
 

--- a/doc/bookish_spork_server.md
+++ b/doc/bookish_spork_server.md
@@ -18,7 +18,7 @@ __Behaviours:__ [`gen_server`](gen_server.md).
 
 
 <pre><code>
-response() = <a href="bookish_spork_response.md#type-response">bookish_spork_response:response()</a> | function()
+response() = <a href="bookish_spork_response.md#type-t">bookish_spork_response:t()</a> | function()
 </code></pre>
 
 <a name="index"></a>

--- a/doc/bookish_spork_server.md
+++ b/doc/bookish_spork_server.md
@@ -18,7 +18,7 @@ __Behaviours:__ [`gen_server`](gen_server.md).
 
 
 <pre><code>
-response() = <a href="bookish_spork_response.md#type-t">bookish_spork_response:t()</a> | function()
+response() = <a href="bookish_spork_response.md#type-t">bookish_spork_response:t()</a> | <a href="bookish_spork.md#type-stub_request_fun">bookish_spork:stub_request_fun()</a>
 </code></pre>
 
 <a name="index"></a>

--- a/src/bookish_spork.erl
+++ b/src/bookish_spork.erl
@@ -50,7 +50,7 @@ stub_request() ->
 -spec stub_request(function() | http_status()) -> ok.
 %% @doc stub request with fun or particular status
 %%
-%% Fun must be {@type fun((bookish_spork_request:request()) -> bookish_spork_response:response())}
+%% Fun must be {@type fun((bookish_spork_request:t()) -> bookish_spork_response:t())}
 %%
 %% Example:
 %%

--- a/src/bookish_spork.erl
+++ b/src/bookish_spork.erl
@@ -21,6 +21,11 @@
 -define(RECEIVE_REQUEST_TIMEOUT_MILLIS, 1000).
 
 -type http_status() :: non_neg_integer().
+-type stub_request_fun() :: fun((bookish_spork_request:t()) -> bookish_spork_response:response()).
+
+-export_type([
+    stub_request_fun/0
+]).
 
 -spec start_server() -> {ok, pid()} | {error, Error :: term()}.
 %% @equiv start_server(32002)
@@ -47,37 +52,37 @@ stop_server() ->
 stub_request() ->
     bookish_spork_server:respond_with(bookish_spork_response:new()).
 
--spec stub_request(function() | http_status()) -> ok.
+-spec stub_request(stub_request_fun() | bookish_spork_response:response()) -> ok.
 %% @doc stub request with fun or particular status
 %%
-%% Fun must be {@type fun((bookish_spork_request:t()) -> bookish_spork_response:t())}
+%% Fun must be {@type fun((bookish_spork_request:t()) -> bookish_spork_response:response())}
 %%
 %% Example:
 %%
 %% ```
-%% stub_request(fun(Request) ->
+%% {@module}:stub_request(fun(Request) ->
 %%     case bookish_spork_request:uri(Request) of
 %%         "/bookish/spork" ->
-%%             bookish_spork_response:new(200, <<"Hello">>);
+%%             [200, [], <<"Hello">>];
 %%         "/admin/sporks" ->
-%%             bookish_spork_response:new(403, <<"It is not possible here">>)
+%%             [403, [], <<"It is not possible here">>]
 %%     end
 %% end)'''
 %%
 %% @end
 stub_request(Fun) when is_function(Fun) ->
     bookish_spork_server:respond_with(Fun);
-stub_request(Status) ->
-    bookish_spork_server:respond_with(bookish_spork_response:new(Status)).
+stub_request(Response) ->
+    bookish_spork_server:respond_with(bookish_spork_response:new(Response)).
 
 -spec stub_request(http_status(), ContentOrHeaders :: binary() | map()) -> ok.
 %% @doc stub request with particular status and content/headers
 stub_request(Status, ContentOrHeaders) ->
     bookish_spork_server:respond_with(bookish_spork_response:new(Status, ContentOrHeaders)).
 
--spec stub_request(http_status(), Headers :: map(), Content :: binary()) -> ok.
+-spec stub_request(http_status(), Headers :: map() | list(), Content :: binary()) -> ok.
 stub_request(Status, Headers, Content) ->
-    bookish_spork_server:respond_with(bookish_spork_response:new(Status, Headers, Content)).
+    bookish_spork_server:respond_with(bookish_spork_response:new({Status, Headers, Content})).
 
 -spec capture_request() -> bookish_spork_request:bookish_spork_request().
 capture_request() ->

--- a/src/bookish_spork_request.erl
+++ b/src/bookish_spork_request.erl
@@ -80,7 +80,7 @@ uri(#request{ uri = Uri}) ->
     Uri.
 
 -spec version(Request :: t()) -> string() | undefined.
-%% @doc http protocol version tuple. Most often would be {1, 1}
+%% @doc http protocol version tuple. Most often would be `{1, 1}'
 version(#request{ version = Version }) ->
     Version.
 

--- a/src/bookish_spork_request.erl
+++ b/src/bookish_spork_request.erl
@@ -31,27 +31,27 @@
     body          :: undefined | binary()
 }).
 
--opaque request() :: #request{}.
+-opaque t() :: #request{}.
 
 -export_type([
-    request/0
+    t/0
 ]).
 
--spec new() -> request().
+-spec new() -> t().
 %% @private
 new() -> #request{}.
 
 -spec request_line(
-    Request :: request(),
+    Request :: t(),
     Method  :: atom(),
     Uri     :: string() | undefined,
     Version :: http_version() | undefined
-) -> request().
+) -> t().
 %% @private
 request_line(Request, Method, Uri, Version) ->
     Request#request{ method = Method, uri = Uri, version = Version }.
 
--spec add_header(Request :: request(), Name :: string(), Value :: string()) -> request().
+-spec add_header(Request :: t(), Name :: string(), Value :: string()) -> t().
 %% @private
 add_header(Request, Name, Value) when is_atom(Name) ->
     add_header(Request, atom_to_list(Name), Value);
@@ -59,7 +59,7 @@ add_header(#request{ headers = Headers } = Request, Name, Value) ->
     HeaderName = string:lowercase(Name),
     Request#request{ headers = maps:put(HeaderName, Value, Headers) }.
 
--spec content_length(Request :: request()) -> integer().
+-spec content_length(Request :: t()) -> integer().
 %% @doc Content-Length header value as intger
 content_length(Request) ->
     case header(Request, "content-length") of
@@ -69,42 +69,42 @@ content_length(Request) ->
             list_to_integer(ContentLength)
     end.
 
--spec method(Request :: request()) -> atom().
+-spec method(Request :: t()) -> atom().
 %% @doc http verb: 'GET', 'POST','PUT', 'DELETE', 'OPTIONS', ...
 method(#request{ method = Method}) ->
     Method.
 
--spec uri(Request :: request()) -> string().
+-spec uri(Request :: t()) -> string().
 %% @doc path with query string
 uri(#request{ uri = Uri}) ->
     Uri.
 
--spec version(Request :: request()) -> string() | undefined.
+-spec version(Request :: t()) -> string() | undefined.
 %% @doc http protocol version tuple. Most often would be {1, 1}
 version(#request{ version = Version }) ->
     Version.
 
--spec header(Request :: request(), HeaderName :: string()) -> string() | undefined.
+-spec header(Request :: t(), HeaderName :: string()) -> string() | undefined.
 %% @doc Returns a particular header from request. Header name is lowerced
 header(#request{ headers = Headers }, HeaderName) ->
     maps:get(HeaderName, Headers, undefined).
 
--spec headers(Request :: request()) -> map().
+-spec headers(Request :: t()) -> map().
 %% @doc http headers map. Header names are normalized and lowercased
 headers(#request{ headers = Headers }) ->
     Headers.
 
--spec body(Request :: request()) -> binary().
+-spec body(Request :: t()) -> binary().
 %% @doc request body
 body(#request{ body = Body }) ->
     Body.
 
--spec body(Request :: request(), Body :: binary()) -> request().
+-spec body(Request :: t(), Body :: binary()) -> t().
 %% @private
 body(Request, Body) ->
     Request#request{ body = Body }.
 
--spec is_keepalive(Request :: request()) -> boolean().
+-spec is_keepalive(Request :: t()) -> boolean().
 %% @doc tells you if the request is keepalive or not [https://tools.ietf.org/html/rfc6223]
 is_keepalive(#request{ headers = #{"connection" := Conn }, version = {1, 0} }) ->
     string:lowercase(Conn) =:= "keep-alive";

--- a/src/bookish_spork_response.erl
+++ b/src/bookish_spork_response.erl
@@ -24,24 +24,24 @@
     content = ?DEFAULT_CONTENT :: binary()
 }).
 
--opaque response() :: #response{}.
+-opaque t() :: #response{}.
 
 -export_type([
-    response/0
+    t/0
 ]).
 
--spec new() -> response().
+-spec new() -> t().
 new() ->
     #response{}.
 
--spec new(Status :: non_neg_integer()) -> response().
+-spec new(Status :: non_neg_integer()) -> t().
 new(Status) ->
     #response{ status = Status }.
 
 -spec new(
     Status :: non_neg_integer(),
     ContentOrHeaders :: binary() | map()
-) -> response().
+) -> t().
 new(Status, Content) when is_binary(Content) ->
     #response{ status = Status, content = Content };
 new(Status, Headers) when is_map(Headers) ->
@@ -51,11 +51,11 @@ new(Status, Headers) when is_map(Headers) ->
     Status  :: non_neg_integer(),
     Headers :: map(),
     Content :: binary()
-) -> response().
+) -> t().
 new(Status, Headers, Content) ->
     #response{ status = Status, headers = Headers, content = Content}.
 
--spec write_str(Response :: response(), Now :: calendar:datetime()) -> binary().
+-spec write_str(Response :: t(), Now :: calendar:datetime()) -> binary().
 write_str(#response{ status = Status, headers = ExtraHeaders, content = Content}, Now) ->
     StatusLine = status_line(Status),
     Headers = headers(ExtraHeaders, Content, Now),

--- a/src/bookish_spork_server.erl
+++ b/src/bookish_spork_server.erl
@@ -18,7 +18,7 @@
 
 -define(SERVER, ?MODULE).
 
--type response() :: bookish_spork_response:t() | function().
+-type response() :: bookish_spork_response:t() | bookish_spork:stub_request_fun().
 
 -record(state, {
     response_queue = queue:new() :: queue:queue({response(), pid()}),
@@ -153,7 +153,7 @@ read_body(Socket, ContentLength) ->
 %% @private
 reply(Socket, ResponseFun, Request) when is_function(ResponseFun) ->
     Response = ResponseFun(Request),
-    reply(Socket, Response, Request);
+    reply(Socket, bookish_spork_response:new(Response), Request);
 reply(Socket, Response, _Request) ->
     String = bookish_spork_response:write_str(Response, calendar:universal_time()),
     gen_tcp:send(Socket, [String]).

--- a/src/bookish_spork_server.erl
+++ b/src/bookish_spork_server.erl
@@ -18,7 +18,7 @@
 
 -define(SERVER, ?MODULE).
 
--type response() :: bookish_spork_response:response() | function().
+-type response() :: bookish_spork_response:t() | function().
 
 -record(state, {
     response_queue = queue:new() :: queue:queue({response(), pid()}),

--- a/test/bookish_spork_response_test.erl
+++ b/test/bookish_spork_response_test.erl
@@ -3,6 +3,16 @@
 
 -define(NOW, {{2018, 4, 28}, {5, 51, 50}}).
 
+new_test_() ->
+    Status = 200,
+    Headers = #{<<"X-Test">> => <<"pants">>},
+    Content = <<"Hello">>,
+    Expected = bookish_spork_response:new(Status, Headers, Content),
+    [?_assertEqual(Expected, bookish_spork_response:new(Expected)),
+    ?_assertEqual(Expected, bookish_spork_response:new({Status, Headers, Content})),
+    ?_assertEqual(Expected, bookish_spork_response:new([Status, Headers, Content])),
+    ?_assertEqual(Expected, bookish_spork_response:new([Status, [{<<"X-Test">>, <<"pants">>}], Content]))].
+
 status_line_test() ->
     ?assertEqual(<<"HTTP/1.1 204 No Content">>, bookish_spork_response:status_line(204)).
 


### PR DESCRIPTION
Changes:
- Rename redundant type names
- Expand `bookish_spork_response:new/1` interface
- Hide  `bookish_spork_response:new/3` constructor in favor `bookish_spork_response:new/1`
- Allow to use lists and tuples as response in fun (fixes #32)
- Minor documentation changes

Rationale:
- see #32 