### PR TITLE
Use explicit request queue instead of process mailbox

### DIFF
--- a/doc/bookish_spork.md
+++ b/doc/bookish_spork.md
@@ -57,7 +57,7 @@ stub_request_fun() = fun((<a href="bookish_spork_request.md#type-t">bookish_spor
 ### capture_request/0 ###
 
 <pre><code>
-capture_request() -&gt; <a href="bookish_spork_request.md#type-bookish_spork_request">bookish_spork_request:bookish_spork_request()</a>
+capture_request() -&gt; {ok, Request::<a href="bookish_spork_request.md#type-t">bookish_spork_request:t()</a>} | {error, ErrorMessage::string()}
 </code></pre>
 <br />
 

--- a/doc/bookish_spork_server.md
+++ b/doc/bookish_spork_server.md
@@ -14,6 +14,16 @@ __Behaviours:__ [`gen_server`](gen_server.md).
 
 
 
+### <a name="type-request">request()</a> ###
+
+
+<pre><code>
+request() = <a href="bookish_spork_request.md#type-t">bookish_spork_request:t()</a>
+</code></pre>
+
+
+
+
 ### <a name="type-response">response()</a> ###
 
 
@@ -26,7 +36,7 @@ response() = <a href="bookish_spork_response.md#type-t">bookish_spork_response:t
 ## Function Index ##
 
 
-<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#respond_with-1">respond_with/1</a></td><td></td></tr><tr><td valign="top"><a href="#start-1">start/1</a></td><td>starts server.</td></tr><tr><td valign="top"><a href="#stop-0">stop/0</a></td><td>stops server.</td></tr></table>
+<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#respond_with-1">respond_with/1</a></td><td></td></tr><tr><td valign="top"><a href="#retrieve_request-0">retrieve_request/0</a></td><td></td></tr><tr><td valign="top"><a href="#start-1">start/1</a></td><td>starts server.</td></tr><tr><td valign="top"><a href="#stop-0">stop/0</a></td><td>stops server.</td></tr></table>
 
 
 <a name="functions"></a>
@@ -39,6 +49,15 @@ response() = <a href="bookish_spork_response.md#type-t">bookish_spork_response:t
 
 <pre><code>
 respond_with(Response::<a href="#type-response">response()</a>) -&gt; ok
+</code></pre>
+<br />
+
+<a name="retrieve_request-0"></a>
+
+### retrieve_request/0 ###
+
+<pre><code>
+retrieve_request() -&gt; {ok, Request::<a href="#type-request">request()</a>} | {error, ErrorMessage::string()}
 </code></pre>
 <br />
 

--- a/src/bookish_spork.erl
+++ b/src/bookish_spork.erl
@@ -18,7 +18,6 @@
 ]).
 
 -define(DEFAUT_PORT, 32002).
--define(RECEIVE_REQUEST_TIMEOUT_MILLIS, 1000).
 
 -type http_status() :: non_neg_integer().
 -type stub_request_fun() :: fun((bookish_spork_request:t()) -> bookish_spork_response:response()).
@@ -84,13 +83,8 @@ stub_request(Status, ContentOrHeaders) ->
 stub_request(Status, Headers, Content) ->
     bookish_spork_server:respond_with(bookish_spork_response:new({Status, Headers, Content})).
 
--spec capture_request() -> bookish_spork_request:bookish_spork_request().
+-spec capture_request() ->
+    {ok, Request :: bookish_spork_request:t()} |
+    {error, ErrorMessage :: string()}.
 capture_request() ->
-    receive
-        {bookish_spork, Request} ->
-            {ok, Request};
-        Unexpected ->
-            {unexpected, Unexpected}
-        after ?RECEIVE_REQUEST_TIMEOUT_MILLIS ->
-            timeout
-    end.
+    bookish_spork_server:retrieve_request().

--- a/test/bookish_spork_SUITE.erl
+++ b/test/bookish_spork_SUITE.erl
@@ -58,7 +58,7 @@ customized_response_test(_Config) ->
 
 failed_capture_test(_Config) ->
     {ok, _Pid} = bookish_spork:start_server(),
-    ?assertEqual(timeout, bookish_spork:capture_request(), "Got timeout when there is no stub"),
+    ?assertMatch({error, _}, bookish_spork:capture_request(), "Got an error when there is no stub"),
     ok = bookish_spork:stop_server().
 
 stub_multiple_requests_test(_Config) ->


### PR DESCRIPTION
Changes:
- Store captured request in gen_server state instead of parent process mailbox
- Fixes some type specs
- Change `bookish_spork:capture_request` error message due to implementation changes

Rationale:
- remove restrictions on the process that could receive a request. Now any process is able to do `capture_request` call. Not only the process who made a request
- Make code more straightforward
