### PR TITLE
Stub multi

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,17 @@ Suitable for Elixir.
 
 There are several ways to test your http interaction
 
-- Real http request to real servers: not very reliable, requires internet
+* Real http request to real servers: not very reliable, requires internet
+* You can use external http server like [`https://httpbin.org/`](https://httpbin.org/) (hackney approach)
+* You can mock your http client library
+* Also you can run an http-server within your application on your localhost on a particualr port
 
-- You can use external http server like [`https://httpbin.org/`](https://httpbin.org/) (hackney approach)
-
-- You can mock your http client library
-
-- Also you can run an http-server within your application on your localhost on a particualr port
 
 The last approach is the best IMHO. It is absolutely http-client agnostic. It doesn't require internet connection or any external utilities.
 
-bookish_spork provides you facilities to test your requests with *real* http server.
+bookish_spork provides you facilities to test your requests with 
+<strong>real</strong>
+ http server.
 
 
 ### <a name="Usage">Usage</a> ###
@@ -100,13 +100,11 @@ As usual the main goal is to test that you send the correct request
 
 It returns you an opaque structure of the request. You can inspect it with
 
-- [`bookish_spork_request:method/1`](http://github.com/tank-bohr/bookish_spork/blob/master/doc/bookish_spork_request.md#method-1)
+* [`bookish_spork_request:method/1`](http://github.com/tank-bohr/bookish_spork/blob/master/doc/bookish_spork_request.md#method-1)
+* [`bookish_spork_request:uri/1`](http://github.com/tank-bohr/bookish_spork/blob/master/doc/bookish_spork_request.md#uri-1)
+* [`bookish_spork_request:headers/1`](http://github.com/tank-bohr/bookish_spork/blob/master/doc/bookish_spork_request.md#headers-1)
+* [`bookish_spork_request:body/1`](http://github.com/tank-bohr/bookish_spork/blob/master/doc/bookish_spork_request.md#body-1)
 
-- [`bookish_spork_request:uri/1`](http://github.com/tank-bohr/bookish_spork/blob/master/doc/bookish_spork_request.md#uri-1)
-
-- [`bookish_spork_request:headers/1`](http://github.com/tank-bohr/bookish_spork/blob/master/doc/bookish_spork_request.md#headers-1)
-
-- [`bookish_spork_request:body/1`](http://github.com/tank-bohr/bookish_spork/blob/master/doc/bookish_spork_request.md#body-1)
 
 
 #### <a name="Bypass_comparision">Bypass comparision</a> ####
@@ -115,11 +113,9 @@ An elixir library [bypass](https://github.com/PSPDFKit-labs/bypass) does pretty 
 
 But bookish_spork has some advantages:
 
-- Bypass depends on `cowboy` and `plug`. Bookish spork has zero dependencies
-
-- Bookish spork works seamlessly with both erlang and elixir. Bypass is supposed to be an elixir only library
-
-- Bookish spork much simpler
+* Bypass depends on `cowboy` and `plug`. Bookish spork has zero dependencies
+* Bookish spork works seamlessly with both erlang and elixir. Bypass is supposed to be an elixir only library
+* Bookish spork much simpler
 
 
 #### <a name="Examples">Examples</a> ####
@@ -159,9 +155,9 @@ random_test(_Config) ->
 
 As you can see there are two types of assertions:
 
-- we check a testee function result
+* we check a testee function result
+* we check a side effect: verifying outgoing request has correct attributes (uri in this case)
 
-- we check a side effect: verifying outgoing request has correct attributes (uri in this case)
 
 <h5><a name="More_complex_expectations">More complex expectations</a></h5>
 
@@ -192,6 +188,29 @@ end
 [Module to work with request](http://github.com/tank-bohr/bookish_spork/blob/master/doc/bookish_spork_request.md)
 
 [Module to work with response](http://github.com/tank-bohr/bookish_spork/blob/master/doc/bookish_spork_response.md)
+
+<h5><a name="Stub_multiple_requests_with_one_response">Stub multiple requests with one response</a></h5>
+
+It can be usefull to stub several requests with one command
+
+```erlang
+
+bookish_spork:stub_multi([200, #{<<"Content-Type" => "text/plan">>}, <<"Pants">>], _Times = 20)
+
+```
+
+The same with the `fun`
+
+```erlang
+
+bookish_spork:stub_multi(fun(Req) ->
+    Body = bookish_spork_request:body(Req),
+    [200, #{<<"X-Respond-With">> => <<"echo">>}, Body]
+end, _Times = 150)
+
+```
+
+As you can see that it's not necessary to build response structure yourself. You can use handy [three-element tuple or list syntax](https://github.com/tank-bohr/bookish_spork/issues/32) to define the response. But the [`bookish_spork_response:new/1`](http://github.com/tank-bohr/bookish_spork/blob/master/doc/bookish_spork_response.md#new-1) still works.
 
 <h5><a name="Elixir_example">Elixir example</a></h5>
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -26,17 +26,17 @@ Suitable for Elixir.
 
 There are several ways to test your http interaction
 
-- Real http request to real servers: not very reliable, requires internet
+* Real http request to real servers: not very reliable, requires internet
+* You can use external http server like [`https://httpbin.org/`](https://httpbin.org/) (hackney approach)
+* You can mock your http client library
+* Also you can run an http-server within your application on your localhost on a particualr port
 
-- You can use external http server like [`https://httpbin.org/`](https://httpbin.org/) (hackney approach)
-
-- You can mock your http client library
-
-- Also you can run an http-server within your application on your localhost on a particualr port
 
 The last approach is the best IMHO. It is absolutely http-client agnostic. It doesn't require internet connection or any external utilities.
 
-bookish_spork provides you facilities to test your requests with *real* http server.
+bookish_spork provides you facilities to test your requests with 
+<strong>real</strong>
+ http server.
 
 
 ### <a name="Usage">Usage</a> ###
@@ -100,13 +100,11 @@ As usual the main goal is to test that you send the correct request
 
 It returns you an opaque structure of the request. You can inspect it with
 
-- [`bookish_spork_request:method/1`](bookish_spork_request.md#method-1)
+* [`bookish_spork_request:method/1`](bookish_spork_request.md#method-1)
+* [`bookish_spork_request:uri/1`](bookish_spork_request.md#uri-1)
+* [`bookish_spork_request:headers/1`](bookish_spork_request.md#headers-1)
+* [`bookish_spork_request:body/1`](bookish_spork_request.md#body-1)
 
-- [`bookish_spork_request:uri/1`](bookish_spork_request.md#uri-1)
-
-- [`bookish_spork_request:headers/1`](bookish_spork_request.md#headers-1)
-
-- [`bookish_spork_request:body/1`](bookish_spork_request.md#body-1)
 
 
 #### <a name="Bypass_comparision">Bypass comparision</a> ####
@@ -115,11 +113,9 @@ An elixir library [bypass](https://github.com/PSPDFKit-labs/bypass) does pretty 
 
 But bookish_spork has some advantages:
 
-- Bypass depends on `cowboy` and `plug`. Bookish spork has zero dependencies
-
-- Bookish spork works seamlessly with both erlang and elixir. Bypass is supposed to be an elixir only library
-
-- Bookish spork much simpler
+* Bypass depends on `cowboy` and `plug`. Bookish spork has zero dependencies
+* Bookish spork works seamlessly with both erlang and elixir. Bypass is supposed to be an elixir only library
+* Bookish spork much simpler
 
 
 #### <a name="Examples">Examples</a> ####
@@ -159,9 +155,9 @@ random_test(_Config) ->
 
 As you can see there are two types of assertions:
 
-- we check a testee function result
+* we check a testee function result
+* we check a side effect: verifying outgoing request has correct attributes (uri in this case)
 
-- we check a side effect: verifying outgoing request has correct attributes (uri in this case)
 
 <h5><a name="More_complex_expectations">More complex expectations</a></h5>
 
@@ -192,6 +188,29 @@ end
 [Module to work with request](bookish_spork_request.md)
 
 [Module to work with response](bookish_spork_response.md)
+
+<h5><a name="Stub_multiple_requests_with_one_response">Stub multiple requests with one response</a></h5>
+
+It can be usefull to stub several requests with one command
+
+```erlang
+
+bookish_spork:stub_multi([200, #{<<"Content-Type" => "text/plan">>}, <<"Pants">>], _Times = 20)
+
+```
+
+The same with the `fun`
+
+```erlang
+
+bookish_spork:stub_multi(fun(Req) ->
+    Body = bookish_spork_request:body(Req),
+    [200, #{<<"X-Respond-With">> => <<"echo">>}, Body]
+end, _Times = 150)
+
+```
+
+As you can see that it's not necessary to build response structure yourself. You can use handy [three-element tuple or list syntax](https://github.com/tank-bohr/bookish_spork/issues/32) to define the response. But the [`bookish_spork_response:new/1`](bookish_spork_response.md#new-1) still works.
 
 <h5><a name="Elixir_example">Elixir example</a></h5>
 

--- a/doc/bookish_spork.md
+++ b/doc/bookish_spork.md
@@ -42,7 +42,7 @@ stub_request_fun() = fun((<a href="bookish_spork_request.md#type-t">bookish_spor
 ## Function Index ##
 
 
-<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#capture_request-0">capture_request/0</a></td><td></td></tr><tr><td valign="top"><a href="#start_server-0">start_server/0</a></td><td>Equivalent to <a href="#start_server-1"><tt>start_server(32002)</tt></a>.</td></tr><tr><td valign="top"><a href="#start_server-1">start_server/1</a></td><td>starts http server on a particular port.</td></tr><tr><td valign="top"><a href="#stop_server-0">stop_server/0</a></td><td>stops http server.</td></tr><tr><td valign="top"><a href="#stub_request-0">stub_request/0</a></td><td>Equivalent to <a href="#stub_request-3"><tt>stub_request(204,
+<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#capture_request-0">capture_request/0</a></td><td></td></tr><tr><td valign="top"><a href="#start_server-0">start_server/0</a></td><td>Equivalent to <a href="#start_server-1"><tt>start_server(32002)</tt></a>.</td></tr><tr><td valign="top"><a href="#start_server-1">start_server/1</a></td><td>starts http server on a particular port.</td></tr><tr><td valign="top"><a href="#stop_server-0">stop_server/0</a></td><td>stops http server.</td></tr><tr><td valign="top"><a href="#stub_multi-2">stub_multi/2</a></td><td>stub multiple requests with one response.</td></tr><tr><td valign="top"><a href="#stub_request-0">stub_request/0</a></td><td>Equivalent to <a href="#stub_request-3"><tt>stub_request(204,
 #{&lt;&lt;"Server"&gt;&gt; =&gt; &lt;&lt;"BookishSpork/0.0.1"&gt;&gt;,
 &lt;&lt;"Date"&gt;&gt; =&gt; &lt;&lt;"Sat, 28 Apr 2018 05:51:50 GMT"&gt;&gt;},
 &lt;&lt;&gt;&gt;)</tt></a>.</td></tr><tr><td valign="top"><a href="#stub_request-1">stub_request/1</a></td><td>stub request with fun or particular status.</td></tr><tr><td valign="top"><a href="#stub_request-2">stub_request/2</a></td><td>stub request with particular status and content/headers.</td></tr><tr><td valign="top"><a href="#stub_request-3">stub_request/3</a></td><td></td></tr></table>
@@ -93,6 +93,26 @@ stop_server() -&gt; ok
 <br />
 
 stops http server
+
+<a name="stub_multi-2"></a>
+
+### stub_multi/2 ###
+
+<pre><code>
+stub_multi(Response::<a href="#type-stub_request_fun">stub_request_fun()</a> | <a href="bookish_spork_response.md#type-response">bookish_spork_response:response()</a>, Times::non_neg_integer()) -&gt; ok
+</code></pre>
+<br />
+
+stub multiple requests with one response
+
+`Response` can be
+
+* either <code>fun((<a href="bookish_spork_request.md#type-t">bookish_spork_request:t()</a>) -> <a href="bookish_spork_response.md#type-response">bookish_spork_response:response()</a>)</code>
+
+* or response data structure <code><a href="bookish_spork_response.md#type-response">bookish_spork_response:response()</a></code>
+
+
+__See also:__ [stub_request/1](#stub_request-1), [bookish_spork_response:new/1](bookish_spork_response.md#new-1).
 
 <a name="stub_request-0"></a>
 

--- a/doc/bookish_spork_server.md
+++ b/doc/bookish_spork_server.md
@@ -36,7 +36,7 @@ response() = <a href="bookish_spork_response.md#type-t">bookish_spork_response:t
 ## Function Index ##
 
 
-<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#respond_with-1">respond_with/1</a></td><td></td></tr><tr><td valign="top"><a href="#retrieve_request-0">retrieve_request/0</a></td><td></td></tr><tr><td valign="top"><a href="#start-1">start/1</a></td><td>starts server.</td></tr><tr><td valign="top"><a href="#stop-0">stop/0</a></td><td>stops server.</td></tr></table>
+<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#respond_with-1">respond_with/1</a></td><td></td></tr><tr><td valign="top"><a href="#respond_with-2">respond_with/2</a></td><td></td></tr><tr><td valign="top"><a href="#retrieve_request-0">retrieve_request/0</a></td><td></td></tr><tr><td valign="top"><a href="#start-1">start/1</a></td><td>starts server.</td></tr><tr><td valign="top"><a href="#stop-0">stop/0</a></td><td>stops server.</td></tr></table>
 
 
 <a name="functions"></a>
@@ -49,6 +49,15 @@ response() = <a href="bookish_spork_response.md#type-t">bookish_spork_response:t
 
 <pre><code>
 respond_with(Response::<a href="#type-response">response()</a>) -&gt; ok
+</code></pre>
+<br />
+
+<a name="respond_with-2"></a>
+
+### respond_with/2 ###
+
+<pre><code>
+respond_with(Response::<a href="#type-response">response()</a>, Times::non_neg_integer()) -&gt; ok
 </code></pre>
 <br />
 

--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -32,17 +32,16 @@ Suitable for Elixir.
 
 There are several ways to test your http interaction
 
-- Real http request to real servers: not very reliable, requires internet
-
-- You can use external http server like [https://httpbin.org/] (hackney approach)
-
-- You can mock your http client library
-
-- Also you can run an http-server within your application on your localhost on a particualr port
+<ul>
+  <li>Real http request to real servers: not very reliable, requires internet</li>
+  <li>You can use external http server like [https://httpbin.org/] (hackney approach)</li>
+  <li>You can mock your http client library</li>
+  <li>Also you can run an http-server within your application on your localhost on a particualr port</li>
+</ul>
 
 The last approach is the best IMHO. It is absolutely http-client agnostic. It doesn't require internet connection or any external utilities.
 
-bookish_spork provides you facilities to test your requests with *real* http server.
+bookish_spork provides you facilities to test your requests with <strong>real</strong> http server.
 
 == Usage ==
 
@@ -101,14 +100,12 @@ As usual the main goal is to test that you send the correct request
 
 It returns you an opaque structure of the request. You can inspect it with
 
-- {@link bookish_spork_request:method/1}
-
-- {@link bookish_spork_request:uri/1}
-
-- {@link bookish_spork_request:headers/1}
-
-- {@link bookish_spork_request:body/1}
-
+<ul>
+  <li>{@link bookish_spork_request:method/1}</li>
+  <li>{@link bookish_spork_request:uri/1}</li>
+  <li>{@link bookish_spork_request:headers/1}</li>
+  <li>{@link bookish_spork_request:body/1}</li>
+</ul>
 
 === Bypass comparision ===
 
@@ -116,11 +113,15 @@ An elixir library <a target="_blank" href="https://github.com/PSPDFKit-labs/bypa
 
 But bookish_spork has some advantages:
 
-- Bypass depends on `cowboy' and `plug'. Bookish spork has zero dependencies
+<ul>
 
-- Bookish spork works seamlessly with both erlang and elixir. Bypass is supposed to be an elixir only library
+  <li>Bypass depends on `cowboy' and `plug'. Bookish spork has zero dependencies</li>
 
-- Bookish spork much simpler
+  <li>Bookish spork works seamlessly with both erlang and elixir. Bypass is supposed to be an elixir only library</li>
+
+  <li>Bookish spork much simpler</li>
+
+</ul>
 
 === Examples ===
 
@@ -153,10 +154,10 @@ Make assertions
 
 As you can see there are two types of assertions:
 
-- we check a testee function result
-
-- we check a side effect: verifying outgoing request has correct attributes (uri in this case)
-
+<ul>
+  <li>we check a testee function result</li>
+  <li>we check a side effect: verifying outgoing request has correct attributes (uri in this case)</li>
+</ul>
 
 ==== More complex expectations ====
 
@@ -186,8 +187,26 @@ end]]>
 {@link bookish_spork_response. Module to work with response}
 
 
-==== Elixir example ====
+==== Stub multiple requests with one response ====
 
+It can be usefull to stub several requests with one command
+
+<pre lang="erlang"><![CDATA[
+bookish_spork:stub_multi([200, #{<<"Content-Type" => "text/plan">>}, <<"Pants">>], _Times = 20)
+]]></pre>
+
+The same with the `fun'
+
+<pre lang="erlang"><![CDATA[
+bookish_spork:stub_multi(fun(Req) ->
+    Body = bookish_spork_request:body(Req),
+    [200, #{<<"X-Respond-With">> => <<"echo">>}, Body]
+end, _Times = 150)
+]]></pre>
+
+As you can see that it's not necessary to build response structure yourself. You can use handy <a target="_blank" href="https://github.com/tank-bohr/bookish_spork/issues/32">three-element tuple or list syntax</a> to define the response. But the {@link bookish_spork_response:new/1} still works.
+
+==== Elixir example ====
 
 <pre lang="elixir">
 defmodule ChuckNorrisApiTest do

--- a/src/bookish_spork.erl
+++ b/src/bookish_spork.erl
@@ -14,6 +14,7 @@
     stub_request/1,
     stub_request/2,
     stub_request/3,
+    stub_multi/2,
     capture_request/0
 ]).
 
@@ -82,6 +83,25 @@ stub_request(Status, ContentOrHeaders) ->
 -spec stub_request(http_status(), Headers :: map() | list(), Content :: binary()) -> ok.
 stub_request(Status, Headers, Content) ->
     bookish_spork_server:respond_with(bookish_spork_response:new({Status, Headers, Content})).
+
+-spec stub_multi(
+    Response :: stub_request_fun() | bookish_spork_response:response(),
+    Times :: non_neg_integer()) -> ok.
+%% @doc stub multiple requests with one response
+%%
+%% `Response' can be
+%% <ul>
+%%   <li>either {@type fun((bookish_spork_request:t()) -> bookish_spork_response:response())}</li>
+%%   <li>or response data structure {@type bookish_spork_response:response()}</li>
+%% </ul>
+%% @see stub_request/1
+%% @see bookish_spork_response:new/1
+%%
+%% @end
+stub_multi(Fun, Times) when is_function(Fun) ->
+    bookish_spork_server:respond_with(Fun, Times);
+stub_multi(Response, Times) ->
+    bookish_spork_server:respond_with(bookish_spork_response:new(Response), Times).
 
 -spec capture_request() ->
     {ok, Request :: bookish_spork_request:t()} |


### PR DESCRIPTION
Changes:
- Add `stub_multi/2` method to stub multiple requests with one response
- Update documentation markup

Rationale:
- It can be very handy to stub several requests at once. Especially when `fun` (#17) is used to handle requests
