### PR TITLE
Narrow interface

### DIFF
--- a/src/bookish_spork_response.erl
+++ b/src/bookish_spork_response.erl
@@ -1,9 +1,7 @@
 -module (bookish_spork_response).
 
 -export([
-    new/0,
     new/1,
-    new/2,
     write_str/2
 ]).
 
@@ -13,19 +11,15 @@
 -define(HTTP11, "HTTP/1.1").
 -define(DEFAULT_SERVER, <<"BookishSpork/0.0.1">>).
 
--define(DEFAULT_STATUS, 204).
--define(DEFAULT_HEADERS, #{}).
--define(DEFAULT_CONTENT, <<>>).
-
 -type response() :: t() | non_neg_integer() |
     {non_neg_integer(), map(), binary()} |
     {non_neg_integer(), list(), binary()} |
     nonempty_list().
 
 -record(response, {
-    status  = ?DEFAULT_STATUS  :: non_neg_integer(),
-    headers = ?DEFAULT_HEADERS :: map(),
-    content = ?DEFAULT_CONTENT :: binary()
+    status  :: non_neg_integer(),
+    headers :: map(),
+    content :: binary()
 }).
 
 -opaque t() :: #response{}.
@@ -34,10 +28,6 @@
     response/0,
     t/0
 ]).
-
--spec new() -> t().
-new() ->
-    #response{}.
 
 -spec new(Response :: response()) -> t().
 %% @doc Constructs a response data structure
@@ -65,18 +55,7 @@ new(Response) when is_record(Response, response) ->
 new({Status, Headers, Content}) ->
     new(Status, Headers, Content);
 new([Status, Headers, Content]) ->
-    new(Status, Headers, Content);
-new(Status) when is_integer(Status) ->
-    #response{ status = Status }.
-
--spec new(
-    Status :: non_neg_integer(),
-    ContentOrHeaders :: binary() | map()
-) -> t().
-new(Status, Content) when is_binary(Content) ->
-    #response{ status = Status, content = Content };
-new(Status, Headers) when is_map(Headers) ->
-    #response{ status = Status, headers = Headers }.
+    new(Status, Headers, Content).
 
 -spec new(
     Status  :: non_neg_integer(),

--- a/src/bookish_spork_server.erl
+++ b/src/bookish_spork_server.erl
@@ -3,7 +3,6 @@
 -export([
     start/1,
     stop/0,
-    respond_with/1,
     respond_with/2,
     retrieve_request/0
 ]).
@@ -41,10 +40,6 @@ start(Port) ->
 %% @doc stops server
 stop() ->
     gen_server:stop(?SERVER).
-
--spec respond_with(Response :: response()) -> ok.
-respond_with(Response) ->
-    gen_server:call(?SERVER, {respond_with, Response}).
 
 -spec respond_with(Response :: response(), Times :: non_neg_integer()) -> ok.
 respond_with(Response, Times) ->

--- a/test/bookish_spork_response_test.erl
+++ b/test/bookish_spork_response_test.erl
@@ -25,46 +25,10 @@ response_headers_test() ->
     >>,
     ?assertEqual(Expected, Actual).
 
-write_str_test_() ->
-    DefaultResponse = bookish_spork_response:new(),
-    CustomsStatus = bookish_spork_response:new(502),
-    CustomsStatusAndContent = bookish_spork_response:new(409, <<"Booookish">>),
-    CustomsStatusAndHeaders = bookish_spork_response:new(307,
-        #{<<"Location">> => <<"https://example.com">>}),
-    CustomResponse = bookish_spork_response:new(200,
+write_str_test() ->
+    Response = bookish_spork_response:new(200,
         #{<<"Content-Type">> => <<"text/plain">>}, <<"Hello">>),
-    [
-        ?_assertEqual(<<
-            "HTTP/1.1 204 No Content\r\n",
-            "Content-Length: 0\r\n",
-            "Date: Sat, 28 Apr 2018 05:51:50 GMT\r\n",
-            "Server: BookishSpork/0.0.1\r\n",
-            "\r\n"
-        >>, bookish_spork_response:write_str(DefaultResponse, ?NOW)),
-        ?_assertEqual(<<
-            "HTTP/1.1 502 Bad Gateway\r\n",
-            "Content-Length: 0\r\n",
-            "Date: Sat, 28 Apr 2018 05:51:50 GMT\r\n",
-            "Server: BookishSpork/0.0.1\r\n"
-            "\r\n"
-        >>, bookish_spork_response:write_str(CustomsStatus, ?NOW)),
-        ?_assertEqual(<<
-            "HTTP/1.1 409 Conflict\r\n",
-            "Content-Length: 9\r\n",
-            "Date: Sat, 28 Apr 2018 05:51:50 GMT\r\n",
-            "Server: BookishSpork/0.0.1\r\n"
-            "\r\n",
-            "Booookish"
-        >>, bookish_spork_response:write_str(CustomsStatusAndContent, ?NOW)),
-        ?_assertEqual(<<
-            "HTTP/1.1 307 Temporary Redirect\r\n",
-            "Content-Length: 0\r\n",
-            "Date: Sat, 28 Apr 2018 05:51:50 GMT\r\n",
-            "Location: https://example.com\r\n"
-            "Server: BookishSpork/0.0.1\r\n"
-            "\r\n"
-        >>, bookish_spork_response:write_str(CustomsStatusAndHeaders, ?NOW)),
-        ?_assertEqual(<<
+    ?assertEqual(<<
             "HTTP/1.1 200 OK\r\n",
             "Content-Length: 5\r\n",
             "Content-Type: text/plain\r\n",
@@ -72,5 +36,4 @@ write_str_test_() ->
             "Server: BookishSpork/0.0.1\r\n"
             "\r\n",
             "Hello"
-        >>, bookish_spork_response:write_str(CustomResponse, ?NOW))
-    ].
+    >>, bookish_spork_response:write_str(Response, ?NOW)).


### PR DESCRIPTION
**Changes:**
- Get rid of `bookish_spork:stub_request/2,3` in favour of 3-element list syntax
- Get rid of `bookish_spork_reques:new/0,2,3` in favour of 3-element list syntax
- See also #34

**Rationale:**

make interface more explicit and concise

before:
```
cloc src test
      10 text files.
      10 unique files.
       1 file ignored.

github.com/AlDanial/cloc v 1.80  T=0.02 s (486.4 files/s, 49391.8 lines/s)
-------------------------------------------------------------------------------
Language                     files          blank        comment           code
-------------------------------------------------------------------------------
Erlang                           9            107             98            709
-------------------------------------------------------------------------------
SUM:                             9            107             98            709
-------------------------------------------------------------------------------
```

after:
```
cloc src test
      10 text files.
      10 unique files.
       1 file ignored.

github.com/AlDanial/cloc v 1.80  T=0.01 s (605.3 files/s, 53403.2 lines/s)
-------------------------------------------------------------------------------
Language                     files          blank        comment           code
-------------------------------------------------------------------------------
Erlang                           9             97             91            606
-------------------------------------------------------------------------------
SUM:                             9             97             91            606
-------------------------------------------------------------------------------
```