### PR TITLE
Elixir interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ defmodule ChuckNorrisApiTest do
     assert ChuckNorrisApi.random == "Chuck norris tried to crank that soulja boy but it wouldn't crank up"
 
     {:ok, request} = :bookish_spork.capture_request
-    assert :bookish_spork_request.uri(request) == '/jokes/random'
+    assert request.uri == '/jokes/random'
   end
 end
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -234,7 +234,7 @@ defmodule ChuckNorrisApiTest do
     assert ChuckNorrisApi.random == "Chuck norris tried to crank that soulja boy but it wouldn't crank up"
 
     {:ok, request} = :bookish_spork.capture_request
-    assert :bookish_spork_request.uri(request) == '/jokes/random'
+    assert request.uri == '/jokes/random'
   end
 end
 

--- a/doc/bookish_spork_request.md
+++ b/doc/bookish_spork_request.md
@@ -56,7 +56,7 @@ Content-Length header value as intger
 ### header/2 ###
 
 <pre><code>
-header(Request::<a href="#type-t">t()</a>, HeaderName::string()) -&gt; string() | undefined
+header(Request::<a href="#type-t">t()</a>, HeaderName::string()) -&gt; string() | nil
 </code></pre>
 <br />
 
@@ -111,7 +111,7 @@ path with query string
 ### version/1 ###
 
 <pre><code>
-version(Request::<a href="#type-t">t()</a>) -&gt; string() | undefined
+version(Request::<a href="#type-t">t()</a>) -&gt; string() | nil
 </code></pre>
 <br />
 

--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -227,7 +227,7 @@ defmodule ChuckNorrisApiTest do
     assert ChuckNorrisApi.random == "Chuck norris tried to crank that soulja boy but it wouldn't crank up"
 
     {:ok, request} = :bookish_spork.capture_request
-    assert :bookish_spork_request.uri(request) == '/jokes/random'
+    assert request.uri == '/jokes/random'
   end
 end
 </pre>

--- a/elvis.config
+++ b/elvis.config
@@ -5,6 +5,12 @@
                 dirs => ["src"],
                 include_dirs => ["include"],
                 filter => "*.erl",
+                rules => [
+                    {elvis_style, function_naming_convention, #{
+                        ignore => [bookish_spork_request],
+                        regex => "^([a-z][a-z0-9]*_?)*$"
+                    }}
+                ],
                 ruleset => erl_files
             },
             #{

--- a/test/bookish_spork_request_test.erl
+++ b/test/bookish_spork_request_test.erl
@@ -2,6 +2,39 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
+elixir_interface_test_() ->
+    Request = bookish_spork_request:new(),
+    [?_assertEqual(Request, bookish_spork_request:'__struct__'()),
+    ?_assertEqual(Request, bookish_spork_request:'__struct__'([])),
+    ?_assertEqual(Request, bookish_spork_request:'__struct__'(#{}))].
+
+new_test_() ->
+    Method = 'POST',
+    Uri = "/foo/bar",
+    Version = {1, 1},
+    Body = <<"Hello">>,
+    Request = lists:foldl(fun(F, Acc) -> F(Acc) end, bookish_spork_request:new(), [
+        fun(Req) -> bookish_spork_request:request_line(Req, Method, Uri, Version) end,
+        fun(Req) -> bookish_spork_request:add_header(Req, "X-Foo", "Bar") end,
+        fun(Req) -> bookish_spork_request:body(Req, Body) end
+    ]),
+    Map = #{
+        method => Method,
+        uri => Uri,
+        version => Version,
+        headers => #{"x-foo" => "Bar"},
+        body => Body
+    },
+    List = [
+        {method, Method},
+        {uri, Uri},
+        {version, Version},
+        {headers, #{"x-foo" => "Bar"}},
+        {body, Body}
+    ],
+    [?_assertEqual(Request, bookish_spork_request:new(Map)),
+    ?_assertEqual(Request, bookish_spork_request:new(List))].
+
 content_length_test_() ->
     Request = bookish_spork_request:new(),
     RequestWithContentLength = bookish_spork_request:add_header(Request, "Content-Length", "17"),


### PR DESCRIPTION
Changes:
- Adds [elixir struct](https://elixir-lang.org/getting-started/structs.html) interface for `bookish_spork_request`

Rationale:

For elixir users sake

```elixir
{:ok, request} = :bookish_spork.capture_request
assert request.uri == '/jokes/random?category=dev'
```
