### PR TITLE
Adds tls extensions to request. Fixes #41

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all doc edown codecov dialyzer test lint eep48 ex_doc gen-cert
+.PHONY: all doc edown codecov dialyzer test lint eep48 ex_doc gen-cert clean
 .DEFAULT_GOAL := all
 
 COVERTOOL_REPORT=_build/test/covertool/bookish_spork.covertool.xml
@@ -46,3 +46,6 @@ $(COVERTOOL_REPORT):
 
 gen-cert:
 	make -C priv/cert all
+
+clean:
+	rebar3 clean

--- a/src/bookish_spork.erl
+++ b/src/bookish_spork.erl
@@ -40,6 +40,7 @@ start_server(Options) ->
 %% @doc stops http server
 stop_server() ->
     bookish_spork_server:stop().
+
 -spec stub_request() -> ok.
 %% @equiv
 %% stub_request(204, #{

--- a/src/bookish_spork_ssl.erl
+++ b/src/bookish_spork_ssl.erl
@@ -12,7 +12,8 @@
 -define(SSL_OPTIONS, [
     {certfile, filename:join(code:priv_dir(bookish_spork), "cert/cert.pem")},
     {keyfile, filename:join(code:priv_dir(bookish_spork), "cert/key.pem")},
-    {verify, verify_none}
+    {verify, verify_none},
+    {handshake, hello}
 ]).
 
 listen(Port, Options) ->
@@ -21,7 +22,9 @@ listen(Port, Options) ->
 -ifdef(OTP_RELEASE).
 accept(ListenSocket) ->
     {ok, Socket} = ssl:transport_accept(ListenSocket),
-    ssl:handshake(Socket).
+    {ok, HsSocket, Ext} = ssl:handshake(Socket),
+    {ok, SslSocket} = ssl:handshake_continue(HsSocket, []),
+    {ok, SslSocket, Ext}.
 -else.
 accept(ListenSocket) ->
     {ok, Socket} = ssl:transport_accept(ListenSocket),

--- a/src/bookish_spork_ssl.erl
+++ b/src/bookish_spork_ssl.erl
@@ -12,12 +12,17 @@
 -define(SSL_OPTIONS, [
     {certfile, filename:join(code:priv_dir(bookish_spork), "cert/cert.pem")},
     {keyfile, filename:join(code:priv_dir(bookish_spork), "cert/key.pem")},
-    {verify, verify_none},
-    {handshake, hello}
+    {verify, verify_none}
 ]).
 
+-ifdef(OTP_RELEASE).
+-define(HELLO, [{handshake, hello}]).
+-else.
+-define(HELLO, []).
+-endif.
+
 listen(Port, Options) ->
-    ssl:listen(Port, Options ++ ?SSL_OPTIONS).
+    ssl:listen(Port, Options ++ ?SSL_OPTIONS ++ ?HELLO).
 
 -ifdef(OTP_RELEASE).
 accept(ListenSocket) ->


### PR DESCRIPTION
Changes:
- Pass TLS extensions to request
- Change `ssl` request field to `ssl_info`
- Close connection properly

Rationale:
-
-
