### PR TITLE
Adds connection_id to request. Fix #48

### DIFF
--- a/elvis.config
+++ b/elvis.config
@@ -11,7 +11,7 @@
                         regex => "^([a-z][a-z0-9]*_?)*$"
                     }},
                     {elvis_style, invalid_dynamic_call, #{
-                        ignore => [bookish_spork_server]
+                        ignore => [bookish_spork_server, bookish_spork_acceptor]
                     }}
                 ],
                 ruleset => erl_files

--- a/src/bookish_spork_acceptor.erl
+++ b/src/bookish_spork_acceptor.erl
@@ -1,0 +1,199 @@
+-module(bookish_spork_acceptor).
+
+-export([start_link/3]).
+
+-behaviour(gen_server).
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
+
+-type transport() :: gen_tcp | bookish_spork_ssl.
+-type socket() :: gen_tcp:socket() | ssl:sslsocket().
+
+-record(state, {
+    server :: pid(),
+    transport :: transport(),
+    listen_socket :: socket(),
+    connection_id :: undefined | binary(),
+    socket :: undefined | socket(),
+    tls_ext :: undefined | ssl:protocol_extensions()
+}).
+
+-type state() :: #state{}.
+
+-spec start_link(Server, Transport, ListenSocket) -> {ok, pid()} when
+    Server :: pid(),
+    Transport :: transport(),
+    ListenSocket :: socket().
+start_link(Server, Transport, ListenSocket) ->
+    gen_server:start_link(?MODULE, {Server, Transport, ListenSocket}, []).
+
+-spec init({Server, Transport, ListenSocket}) -> {ok, State} when
+    State :: state(),
+    Server :: pid(),
+    Transport :: transport(),
+    ListenSocket :: socket().
+%% @private
+init({Server, Transport, ListenSocket}) ->
+    ok = accept(),
+    {ok, #state{server = Server, transport = Transport, listen_socket = ListenSocket}}.
+
+%% @private
+handle_call(_Request, _From, State) ->
+    {reply, {error, unknown_call}, State}.
+
+%% @private
+handle_cast(accept, State) ->
+    {ok, NewState} = accept(State),
+    {noreply, NewState};
+handle_cast(handle_connection, State) ->
+    ok = handle_connection(State),
+    {noreply, State};
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+%% @private
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+%% @private
+terminate(_Reason, _State) ->
+    ok.
+
+%% @private
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+-spec accept() -> ok.
+%% @private
+accept() ->
+    gen_server:cast(self(), accept).
+
+-spec accept(State) -> {ok, NewState} when
+    State :: state(),
+    NewState :: state().
+%% @private
+accept(#state{transport = Transport, listen_socket = ListenSocket} = State) ->
+    {Socket, TlsExt} = case Transport:accept(ListenSocket) of
+        {ok, Sock, Ext} ->
+            {Sock, Ext};
+        {ok, Sock} ->
+            {Sock, undefined}
+    end,
+    ConnectionId = generate_id(),
+    NewState = State#state{connection_id = ConnectionId, socket = Socket, tls_ext = TlsExt},
+    ok = handle_connection(),
+    {ok, NewState}.
+
+-spec handle_connection() -> ok.
+%% @private
+handle_connection() ->
+    gen_server:cast(self(), handle_connection).
+
+-spec handle_connection(State :: state()) -> ok.
+%% @private
+handle_connection(#state{transport = Transport, socket = Socket, server = Server} = State) ->
+    case receive_request(State) of
+        {ok, Request} ->
+            ok = bookish_spork_server:store_request(Server, Request),
+            case bookish_spork_server:response(Server) of
+                {ok, Response} ->
+                    ok = reply(Transport, Socket, Response, Request),
+                    complete_connection(State, Request);
+                {error, no_response} ->
+                    Transport:close(Socket)
+            end;
+        socket_closed ->
+            accept()
+    end.
+
+-spec complete_connection(State, Request) -> ok when
+    State :: state(),
+    Request :: bookish_spork_request:t().
+%% @private
+complete_connection(#state{transport = Transport, socket = Socket}, Request) ->
+    case bookish_spork_request:is_keepalive(Request) of
+        true ->
+            ok = handle_connection();
+        false ->
+            ok = Transport:shutdown(Socket, read_write),
+            ok = gen_server:cast(self(), accept)
+    end.
+
+-spec receive_request(State :: state()) -> Result when
+    Result :: {ok, Request} | socket_closed,
+    Request :: bookish_spork_request:t().
+%% @private
+receive_request(State) ->
+    #state{
+        transport = Transport,
+        connection_id = ConnectionId,
+        socket = Socket,
+        tls_ext = TlsExt
+    } = State,
+    Request = bookish_spork_request:new(ConnectionId, Socket, TlsExt),
+    read_from_socket(Transport, Socket, Request).
+
+-spec read_from_socket(Transport, Socket, RequestIn) -> Result when
+    Transport :: transport(),
+    Socket :: socket(),
+    RequestIn :: bookish_spork_request:t(),
+    Result :: {ok, RequestOut} | socket_closed,
+    RequestOut :: bookish_spork_request:t().
+%% @private
+read_from_socket(Transport, Socket, RequestIn) ->
+    case Transport:recv(Socket, 0) of
+        {ok, {http_request, Method, {abs_path, Uri}, Version}} ->
+            RequestOut = bookish_spork_request:request_line(RequestIn, Method, Uri, Version),
+            read_from_socket(Transport, Socket, RequestOut);
+        {ok, {http_header, _, Header, _, Value}} ->
+            RequestOut = bookish_spork_request:add_header(RequestIn, Header, Value),
+            read_from_socket(Transport, Socket, RequestOut);
+        {ok, http_eoh} ->
+            Body = read_body(Transport, Socket, bookish_spork_request:content_length(RequestIn)),
+            RequestOut = bookish_spork_request:body(RequestIn, Body),
+            {ok, RequestOut};
+        {http_error, HttpError} ->
+            erlang:error({http_error, HttpError}, [Transport, Socket, RequestIn]);
+        {error, closed} ->
+            socket_closed
+    end.
+
+-spec read_body(Transport, Socket, ContentLength) -> Body when
+    Transport :: transport(),
+    Socket :: socket(),
+    ContentLength :: non_neg_integer(),
+    Body :: binary().
+%% @private
+read_body(_Transport, _Socket, 0) ->
+    <<>>;
+read_body(Transport, Socket, ContentLength) ->
+    inet:setopts(Socket, [{packet, raw}]),
+    {ok, Body} = Transport:recv(Socket, ContentLength),
+    inet:setopts(Socket, [{packet, http}]),
+    Body.
+
+-spec reply(Transport, Socket, Response, Request) -> ok when
+    Transport :: transport(),
+    Socket :: socket(),
+    Response :: bookish_spork:stub_request_fun() | bookish_spork_response:t(),
+    Request :: bookish_spork_request:t().
+%% @private
+reply(Transport, Socket, ResponseFun, Request) when is_function(ResponseFun) ->
+    Response = ResponseFun(Request),
+    reply(Transport, Socket, bookish_spork_response:new(Response), Request);
+reply(Transport, Socket, Response, _Request) ->
+    String = bookish_spork_response:write_str(Response, calendar:universal_time()),
+    Transport:send(Socket, [String]).
+
+-spec generate_id() -> Id :: binary().
+%% @doc generates unique id to be a connection id
+generate_id() ->
+    Bytes = crypto:strong_rand_bytes(7),
+    Base64 = base64:encode(Bytes),
+    string:trim(Base64, trailing, "=").

--- a/src/bookish_spork_acceptor_sup.erl
+++ b/src/bookish_spork_acceptor_sup.erl
@@ -1,0 +1,42 @@
+-module(bookish_spork_acceptor_sup).
+-export([
+    start_link/3,
+    stop/1
+]).
+
+-behaviour(supervisor).
+-export([
+    init/1
+]).
+
+-define(CHILD(I, Args), #{
+    id => I,
+    start => {I, start_link, Args},
+    restart => permanent,
+    shutdown => 5000,
+    type => worker,
+    modules => [I]
+}).
+
+-define(SUP_FLAGS, #{
+    strategy => one_for_one,
+    intensity => 5,
+    period => 10
+}).
+
+-spec start_link(Server, Transport, ListenSocket) -> {ok, pid()} when
+    Server :: pid(),
+    Transport :: gen_tcp | bookish_spork_ssl,
+    ListenSocket :: gen_tcp:socket() | ssl:sslsocket().
+start_link(Server, Transport, ListenSocket) ->
+    supervisor:start_link(?MODULE, [Server, Transport, ListenSocket]).
+
+stop(Sup) ->
+    ok = supervisor:terminate_child(Sup, bookish_spork_acceptor),
+    ok = supervisor:delete_child(Sup, bookish_spork_acceptor),
+    ok = gen_server:stop(Sup).
+
+%% @private
+init(Args) ->
+    ChildSpec = ?CHILD(bookish_spork_acceptor, Args),
+    {ok, {?SUP_FLAGS, [ChildSpec]}}.

--- a/src/bookish_spork_server.erl
+++ b/src/bookish_spork_server.erl
@@ -7,6 +7,11 @@
     retrieve_request/0
 ]).
 
+-export([
+    store_request/2,
+    response/1
+]).
+
 -behaviour(gen_server).
 
 -export([
@@ -26,7 +31,7 @@
 -record(state, {
     response_queue = queue:new() :: queue:queue(response()),
     request_queue = queue:new() :: queue:queue(request()),
-    acceptor :: pid(),
+    acceptor_sup :: pid(),
     socket :: gen_tcp:socket() | ssl:sslsocket(),
     transport :: gen_tcp | bookish_spork_ssl
 }).
@@ -51,15 +56,15 @@ respond_with(Response, Times) ->
 retrieve_request() ->
     gen_server:call(?SERVER, request).
 
--spec store_request(Request :: request()) -> ok.
-%% @private
-store_request(Request) ->
-    gen_server:call(?SERVER, {request, Request}).
+-spec store_request(Server :: pid(), Request :: request()) -> ok.
+%% @doc Used by {@link bookish_spork_acceptor}
+store_request(Server, Request) ->
+    gen_server:call(Server, {request, Request}).
 
--spec response() -> {ok, response()} | {error, no_response}.
-%% @private
-response() ->
-    gen_server:call(?SERVER, response).
+-spec response(Server :: pid()) -> {ok, response()} | {error, no_response}.
+%% @doc Used by {@link bookish_spork_acceptor}
+response(Server) ->
+    gen_server:call(Server, response).
 
 -spec init(Options :: proplists:proplist()) -> {ok, state()}.
 %% @private
@@ -72,8 +77,8 @@ init(Options) ->
         {active, false},
         {reuseaddr, true}
     ]),
-    {ok, Acceptor} = accept(Transport, ListenSocket),
-    {ok, #state{transport = Transport, socket = ListenSocket, acceptor = Acceptor}}.
+    {ok, AcceptorSup} = bookish_spork_acceptor_sup:start_link(self(), Transport, ListenSocket),
+    {ok, #state{transport = Transport, socket = ListenSocket, acceptor_sup = AcceptorSup}}.
 
 -spec handle_call(
     {respond_with, bookish_spork_response:response()},
@@ -117,84 +122,14 @@ handle_info(_Info, State) ->
 
 -spec terminate(Reason :: term(), State :: state()) -> ok.
 %% @private
-terminate(_Reason, #state{transport = Transport, socket = ListenSocket}) ->
-    Transport:close(ListenSocket).
-
-%% @private
-accept(Transport, ListenSocket) ->
-    AcceptorPid = spawn_link(fun AcceptorFun() ->
-        {Socket, TlsExt} = case Transport:accept(ListenSocket) of
-            {ok, Sock, Ext} -> {Sock, Ext};
-            {ok, Sock}      -> {Sock, undefined}
-        end,
-        ok = handle_connection(Transport, Socket, TlsExt),
-        AcceptorFun()
-    end),
-    {ok, AcceptorPid}.
-
-%% @private
-handle_connection(Transport, Socket, TlsExt) ->
-    case receive_request(Transport, Socket, TlsExt) of
-        {ok, Request} ->
-            store_request(Request),
-            case response() of
-                {ok, Response} ->
-                    ok = reply(Transport, Socket, Response, Request),
-                    complete_connection(Request, Transport, Socket, TlsExt);
-                {error, no_response} ->
-                    Transport:close(Socket)
-            end;
-        socket_closed ->
-            ok
-    end.
-
-%% @private
-complete_connection(Request, Transport, Socket, TlsExt) ->
-    case bookish_spork_request:is_keepalive(Request) of
-        true ->
-            handle_connection(Transport, Socket, TlsExt);
-        false ->
-            Transport:shutdown(Socket, read_write)
-    end.
-
-%% @private
-receive_request(Transport, Socket, TlsExt) ->
-    Request = bookish_spork_request:new_from_socket(Socket, TlsExt),
-    read_from_socket(Transport, Socket, Request).
-
-%% @private
-read_from_socket(Transport, Socket, RequestIn) ->
-    case Transport:recv(Socket, 0) of
-        {ok, {http_request, Method, {abs_path, Uri}, Version}} ->
-            RequestOut = bookish_spork_request:request_line(RequestIn, Method, Uri, Version),
-            read_from_socket(Transport, Socket, RequestOut);
-        {ok, {http_header, _, Header, _, Value}} ->
-            RequestOut = bookish_spork_request:add_header(RequestIn, Header, Value),
-            read_from_socket(Transport, Socket, RequestOut);
-        {ok, http_eoh} ->
-            Body = read_body(Transport, Socket, bookish_spork_request:content_length(RequestIn)),
-            RequestOut = bookish_spork_request:body(RequestIn, Body),
-            {ok, RequestOut};
-        {error, closed} ->
-            socket_closed
-    end.
-
-%% @private
-read_body(_Transport, _Socket, 0) ->
-    <<>>;
-read_body(Transport, Socket, ContentLength) ->
-    inet:setopts(Socket, [{packet, raw}]),
-    {ok, Body} = Transport:recv(Socket, ContentLength),
-    inet:setopts(Socket, [{packet, http}]),
-    Body.
-
-%% @private
-reply(Transport, Socket, ResponseFun, Request) when is_function(ResponseFun) ->
-    Response = ResponseFun(Request),
-    reply(Transport, Socket, bookish_spork_response:new(Response), Request);
-reply(Transport, Socket, Response, _Request) ->
-    String = bookish_spork_response:write_str(Response, calendar:universal_time()),
-    Transport:send(Socket, [String]).
+terminate(_Reason, State) ->
+    #state{
+        transport = Transport,
+        socket = ListenSocket,
+        acceptor_sup = AcceptorSup
+    } = State,
+    ok = bookish_spork_acceptor_sup:stop(AcceptorSup),
+    ok = Transport:close(ListenSocket).
 
 %% @private
 detect_transport(Options) ->

--- a/src/bookish_spork_server.erl
+++ b/src/bookish_spork_server.erl
@@ -86,8 +86,6 @@ init(Options) ->
     State :: state()
 ) -> {reply, {ok, pid()}, state()}.
 %% @private
-handle_call({respond_with, Response}, _From, #state{response_queue = Q} = State) ->
-    {reply, ok, State#state{response_queue = queue:in(Response, Q)}};
 handle_call({respond_with, Response, Times}, _From, #state{response_queue = Q1} = State) ->
     Q2 = lists:foldl(fun(_, Q) -> queue:in(Response, Q) end, Q1, lists:seq(1, Times)),
     {reply, ok, State#state{response_queue = Q2}};

--- a/test/bookish_spork_SUITE.erl
+++ b/test/bookish_spork_SUITE.erl
@@ -190,7 +190,8 @@ response(Request) ->
     [200, #{}, Body].
 
 start_server(Config) ->
-    start_server([], Config).
+    {ok, Pid} = bookish_spork:start_server(),
+    [{server, Pid} | Config].
 
 start_server(Options, Config) ->
     {ok, Pid} = bookish_spork:start_server(Options),


### PR DESCRIPTION


Changes:
- Move out Acceptor process out of the server to separate gen_server
- Add `socket` to the request as well as `connection_id` field
- Test refactoring: move `start_server`/`stop_server` to common test callbacks `init_per_testcase`/`end_per_testcase` respectively

Rationale:

- see #48