### PR TITLE
Use blocking queue for requests keeping. Fixes #53

### DIFF
--- a/src/bookish_spork.erl
+++ b/src/bookish_spork.erl
@@ -13,7 +13,8 @@
     stub_request/0,
     stub_request/1,
     stub_request/2,
-    capture_request/0
+    capture_request/0,
+    capture_request/1
 ]).
 
 -define(DEFAULT_STATUS, 204).
@@ -88,4 +89,11 @@ stub_request(Response, Times) ->
 
 -spec capture_request() -> {ok, Request :: bookish_spork_request:t()} | {error, Error :: term()}.
 capture_request() ->
-    bookish_spork_server:retrieve_request().
+    capture_request(_Timeout = 0).
+
+-spec capture_request(Timeout) -> {ok, Request} | {error, Error} when
+    Error :: term(),
+    Request :: bookish_spork_request:t(),
+    Timeout :: non_neg_integer().
+capture_request(Timeout) ->
+    bookish_spork_server:retrieve_request(Timeout).

--- a/src/bookish_spork_blocking_queue.erl
+++ b/src/bookish_spork_blocking_queue.erl
@@ -12,8 +12,7 @@
     init/1,
     handle_call/3,
     handle_cast/2,
-    handle_info/2,
-    terminate/2
+    handle_info/2
 ]).
 
 -type element() :: any().
@@ -88,10 +87,6 @@ handle_info({timeout, Client}, #state{waiting = Waiting} = State) ->
             Waiting
     end,
     {noreply, State#state{waiting = Remaining}}.
-
-%% @private
-terminate(_Reason, _State) ->
-    ok.
 
 enqueue_client(Client, Waiting, 0) ->
     gen_server:reply(Client, {error, timeout}),

--- a/src/bookish_spork_blocking_queue.erl
+++ b/src/bookish_spork_blocking_queue.erl
@@ -1,0 +1,103 @@
+-module(bookish_spork_blocking_queue).
+
+-export([
+    start_link/0,
+    in/2,
+    out/1,
+    out/2
+]).
+
+-behaviour(gen_server).
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2
+]).
+
+-type element() :: any().
+
+-record(state, {
+    waiting = queue:new() :: queue:queue(element()),
+    elements = queue:new() :: queue:queue(element())
+}).
+
+-define(DEFAULT_TIMEOUT_MILLIS, 5000).
+
+start_link() ->
+    gen_server:start_link(?MODULE, [], []).
+
+-spec in(Pid :: pid(), Element :: element()) -> ok.
+in(Pid, Element) ->
+    gen_server:call(Pid, {enqueue, Element}).
+
+-spec out(Pid :: pid()) -> {ok, element()} | {error, timeout}.
+out(Pid) ->
+    out(Pid, ?DEFAULT_TIMEOUT_MILLIS).
+
+-spec out(Pid, Timeout) -> {ok, element()} | {error, timeout} when
+    Pid :: pid(),
+    Timeout :: non_neg_integer() | infinity.
+out(Pid, Timeout) ->
+    gen_server:call(Pid, {dequeue, Timeout}, infinity).
+
+
+%% @private
+init([]) ->
+    {ok, #state{}}.
+
+%% @private
+handle_call({dequeue, Timeout}, From, #state{waiting = Waiting} = State) ->
+    case queue:out(State#state.elements) of
+        {empty, _} ->
+            %% no elements therefore we wait
+            {noreply, State#state{waiting = enqueue_client(From, Waiting, Timeout)}};
+        {{value, Element}, RemainingElements} ->
+            %% return the next element
+            {reply, {ok, Element}, State#state{elements = RemainingElements}}
+    end;
+handle_call({enqueue, Element}, From, #state{elements = Elements} = State) ->
+    case queue:out(State#state.waiting) of
+        {empty, _} ->
+            %% no waiters we just save the item
+            {reply, ok, State#state{elements = queue:in(Element, Elements)}};
+        {{value, {Pid, _} = Client}, Remaining} ->
+            %% feed next waiter
+            case is_process_alive(Pid) of
+                false ->
+                    handle_call({enqueue, Element}, From, State#state{waiting = Remaining});
+                true ->
+                    gen_server:reply(Client, {ok, Element}),
+                    {reply, ok, State#state{waiting = Remaining}}
+            end
+    end.
+
+%% @private
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+%% @private
+handle_info({timeout, Client}, #state{waiting = Waiting} = State) ->
+    Remaining = case queue:member(Client, Waiting) of
+        true ->
+            gen_server:reply(Client, {error, timeout}),
+            queue:filter(fun(Item) -> Item =:= Client end, Waiting);
+        false ->
+            %% Already replied
+            Waiting
+    end,
+    {noreply, State#state{waiting = Remaining}}.
+
+%% @private
+terminate(_Reason, _State) ->
+    ok.
+
+enqueue_client(Client, Waiting, 0) ->
+    gen_server:reply(Client, {error, timeout}),
+    Waiting;
+enqueue_client(Client, Waiting, Timeout) when is_atom(Timeout) ->
+    queue:in(Client, Waiting);
+enqueue_client(Client, Waiting, Timeout) when is_integer(Timeout) andalso Timeout > 0 ->
+    {ok, _} = timer:send_after(Timeout, {timeout, Client}),
+    queue:in(Client, Waiting).

--- a/test/bookish_spork_blocking_queue_SUITE.erl
+++ b/test/bookish_spork_blocking_queue_SUITE.erl
@@ -1,0 +1,29 @@
+-module (bookish_spork_blocking_queue_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-export([
+    all/0
+]).
+
+-export([
+    basic_test/1
+]).
+
+all() ->
+    [basic_test].
+
+basic_test(_Config) ->
+    {ok, Pid} = bookish_spork_blocking_queue:start_link(),
+    {FetcherPid, Ref} = spawn_monitor(fun() ->
+        {ok, Value} = bookish_spork_blocking_queue:out(Pid),
+        ?assertEqual(pants, Value)
+    end),
+    ct:sleep(500),
+    ok = bookish_spork_blocking_queue:in(Pid, pants),
+    ?assertEqual({error, timeout}, bookish_spork_blocking_queue:out(Pid, 500)),
+    ok = receive
+        {'DOWN', Ref, process, FetcherPid, normal} -> ok
+        after 500                                  -> timeout
+    end.

--- a/test/bookish_spork_blocking_queue_SUITE.erl
+++ b/test/bookish_spork_blocking_queue_SUITE.erl
@@ -8,16 +8,18 @@
 ]).
 
 -export([
-    basic_test/1
+    basic_test/1,
+    dead_process_awaiting_test/1,
+    wait_for_timer_test/1
 ]).
 
 all() ->
-    [basic_test].
+    [basic_test, dead_process_awaiting_test, wait_for_timer_test].
 
 basic_test(_Config) ->
     {ok, Pid} = bookish_spork_blocking_queue:start_link(),
     {FetcherPid, Ref} = spawn_monitor(fun() ->
-        {ok, Value} = bookish_spork_blocking_queue:out(Pid),
+        {ok, Value} = bookish_spork_blocking_queue:out(Pid, infinity),
         ?assertEqual(pants, Value)
     end),
     ct:sleep(500),
@@ -26,4 +28,34 @@ basic_test(_Config) ->
     ok = receive
         {'DOWN', Ref, process, FetcherPid, normal} -> ok
         after 500                                  -> timeout
+    end.
+
+dead_process_awaiting_test(_Config) ->
+    {ok, Pid} = bookish_spork_blocking_queue:start_link(),
+    {DeadMan, Ref1} = spawn_monitor(fun() -> bookish_spork_blocking_queue:out(Pid) end),
+    ct:sleep(500),
+    exit(DeadMan, sucker_punch),
+    sucker_punch = receive
+        {'DOWN', Ref1, process, DeadMan, Reason1} -> Reason1
+    end,
+    {Fetcher, Ref2} = spawn_monitor(fun() ->
+        {ok, Value} = bookish_spork_blocking_queue:out(Pid),
+        ?assertEqual(pants, Value)
+    end),
+    ok = bookish_spork_blocking_queue:in(Pid, pants),
+    normal = receive
+        {'DOWN', Ref2, process, Fetcher, Reason2} -> Reason2
+    end.
+
+wait_for_timer_test(_Config) ->
+    {ok, Pid} = bookish_spork_blocking_queue:start_link(),
+    {Client, Ref} = spawn_monitor(fun() ->
+        {ok, Value} = bookish_spork_blocking_queue:out(Pid, 1000),
+        ?assertEqual(pants, Value)
+    end),
+    ct:sleep(500),
+    ok = bookish_spork_blocking_queue:in(Pid, pants),
+    ct:sleep(500),
+    ok = receive
+        {'DOWN', Ref, process, Client, normal} -> ok
     end.


### PR DESCRIPTION
Changes:

- blocking queue implementation
- add `bookish_spork:capture_request/1` with `Timeout` parameter to wait async requests
- blocks caller process, not a server one

Rationale:

see #53 
