### PR TITLE
Refactoring nested cases with `reduce_while`. Fixes #58

### DIFF
--- a/src/bookish_spork_acceptor_sup.erl
+++ b/src/bookish_spork_acceptor_sup.erl
@@ -1,13 +1,8 @@
--module(bookish_spork_sup).
--export([
-    start_acceptor_sup/2,
-    stop/1
-]).
+-module(bookish_spork_acceptor_sup).
+-export([start_link/2]).
 
 -behaviour(supervisor).
--export([
-    init/1
-]).
+-export([init/1]).
 
 -define(SUP_FLAGS, #{
     strategy  => one_for_one,
@@ -15,14 +10,11 @@
     period    => 10
 }).
 
--spec start_acceptor_sup(Server, ListenSocket) -> {ok, pid()} when
+-spec start_link(Server, ListenSocket) -> {ok, pid()} when
     Server       :: pid(),
     ListenSocket :: bookish_spork_transport:listen().
-start_acceptor_sup(Server, ListenSocket) ->
+start_link(Server, ListenSocket) ->
     supervisor:start_link(?MODULE, [Server, ListenSocket]).
-
-stop(Sup) ->
-    ok = gen_server:stop(Sup).
 
 %% @private
 init(Args) ->

--- a/src/bookish_spork_server.erl
+++ b/src/bookish_spork_server.erl
@@ -80,7 +80,7 @@ init(Options) ->
     Port = proplists:get_value(port, Options, ?DEFAULT_PORT),
     Mod = detect_transport(Options),
     ListenSocket = bookish_spork_transport:listen(Mod, Port),
-    {ok, AcceptorSup} = bookish_spork_sup:start_acceptor_sup(self(), ListenSocket),
+    {ok, AcceptorSup} = bookish_spork_acceptor_sup:start_link(self(), ListenSocket),
     {ok, RequestQueuePid} = bookish_spork_blocking_queue:start_link(),
     {ok, #state{request_queue = RequestQueuePid,
         listen_socket = ListenSocket, acceptor_sup = AcceptorSup}}.
@@ -126,7 +126,7 @@ terminate(_Reason, State) ->
         listen_socket = ListenSocket,
         acceptor_sup  = AcceptorSup
     } = State,
-    ok = bookish_spork_sup:stop(AcceptorSup),
+    ok = gen_server:stop(AcceptorSup),
     ok = bookish_spork_transport:close(ListenSocket).
 
 %% @private

--- a/src/bookish_spork_ssl.erl
+++ b/src/bookish_spork_ssl.erl
@@ -4,7 +4,7 @@
 
 -export([
     listen/2,
-    accept/2,
+    accept/1,
     recv/2,
     send/2,
     close/1,
@@ -27,14 +27,14 @@ listen(Port, Options) ->
     ssl:listen(Port, Options ++ ?SSL_OPTIONS ++ ?HELLO).
 
 -ifdef(OTP_RELEASE).
-accept(ListenSocket, Timeout) ->
-    {ok, Socket} = ssl:transport_accept(ListenSocket, Timeout),
+accept(ListenSocket) ->
+    {ok, Socket} = ssl:transport_accept(ListenSocket),
     {ok, HsSocket, Ext} = ssl:handshake(Socket),
     {ok, SslSocket} = ssl:handshake_continue(HsSocket, []),
     {ok, SslSocket, Ext}.
 -else.
-accept(ListenSocket, Timeout) ->
-    {ok, Socket} = ssl:transport_accept(ListenSocket, Timeout),
+accept(ListenSocket) ->
+    {ok, Socket} = ssl:transport_accept(ListenSocket),
     ok = ssl:ssl_accept(Socket),
     {ok, Socket}.
 -endif.

--- a/src/bookish_spork_sup.erl
+++ b/src/bookish_spork_sup.erl
@@ -1,8 +1,6 @@
 -module(bookish_spork_sup).
 -export([
     start_acceptor_sup/2,
-    start_handler_sup/1,
-    start_handler/2,
     stop/1
 ]).
 
@@ -11,14 +9,8 @@
     init/1
 ]).
 
--define(ACCEPTOR_SUP_FLAGS, #{
+-define(SUP_FLAGS, #{
     strategy  => one_for_one,
-    intensity => 5,
-    period    => 10
-}).
-
--define(HANDLER_SUP_FLAGS, #{
-    strategy  => simple_one_for_one,
     intensity => 5,
     period    => 10
 }).
@@ -27,19 +19,13 @@
     Server       :: pid(),
     ListenSocket :: bookish_spork_transport:listen().
 start_acceptor_sup(Server, ListenSocket) ->
-    supervisor:start_link(?MODULE, {acceptor, [Server, ListenSocket]}).
-
-start_handler_sup(Server) ->
-    supervisor:start_link(?MODULE, {handler, [Server]}).
-
-start_handler(Sup, Transport) ->
-    supervisor:start_child(Sup, [Transport]).
+    supervisor:start_link(?MODULE, [Server, ListenSocket]).
 
 stop(Sup) ->
     ok = gen_server:stop(Sup).
 
 %% @private
-init({acceptor, Args}) ->
-    {ok, {?ACCEPTOR_SUP_FLAGS, [bookish_spork_acceptor:child_spec(Args)]}};
-init({handler, Args}) ->
-    {ok, {?HANDLER_SUP_FLAGS, [bookish_spork_handler:child_spec(Args)]}}.
+init(Args) ->
+    {ok, {?SUP_FLAGS, [
+        bookish_spork_acceptor:child_spec(Args)
+    ]}}.

--- a/src/bookish_spork_transport.erl
+++ b/src/bookish_spork_transport.erl
@@ -38,9 +38,8 @@
     Result       :: {ok, ListenSocket} | {error, Reason},
     ListenSocket :: socket(),
     Reason       :: system_limit | inet:posix().
--callback accept(ListenSocket, Timeout) -> Result when
+-callback accept(ListenSocket) -> Result when
     ListenSocket :: socket(),
-    Timeout      :: timeout(),
     Result       :: {ok, Socket} | {ok, Socket, Ext} | {error, Reason},
     Socket       :: socket(),
     Ext          :: ssl:protocol_extensions(),
@@ -74,7 +73,6 @@
     {active, false},
     {reuseaddr, true}
 ]).
--define(ACCEPT_TIMEOUT, 5000).
 -define(IS_SSL_SOCKET(Socket), is_tuple(Socket) andalso element(1, Socket) =:= sslsocket).
 
 -spec listen(callback_module(), inet:port_number()) -> listen().
@@ -84,7 +82,7 @@ listen(Module, Port) ->
 
 -spec accept(listen()) -> t().
 accept(#listen{socket = ListenSocket, module = Module}) ->
-    case Module:accept(ListenSocket, ?ACCEPT_TIMEOUT) of
+    case Module:accept(ListenSocket) of
         {ok, Socket, Ext} ->
             #transport{id = generate_id(), module = Module, socket = Socket, ssl_ext = Ext};
         {ok, Socket} ->

--- a/test/bookish_spork_SUITE.erl
+++ b/test/bookish_spork_SUITE.erl
@@ -101,7 +101,7 @@ stub_multiple_requests(_Config) ->
         {"http://localhost:32002/pulti", []}, [], [{body_format, binary}]),
     {ok, Request2} = bookish_spork:capture_request(),
     ?assertEqual("/pulti", bookish_spork_request:uri(Request2)),
-    ?assertMatch({error, _},
+    ?assertMatch({error, socket_closed_remotely},
         httpc:request(get, {"http://localhost:32002", []}, [], [{body_format, binary}])).
 
 stub_with_fun(_Config) ->


### PR DESCRIPTION
Changes:

- Refactoring nested cases with `reduce_while`
- nuke handler supervisor
- get rid of accept timeout
- close connection when no bookish_spork response

Rationale:

- see #58
- handler supervisor was redundant due to it concealed errors
- accept timeout must be infinity. Prepare for #62 
- we have to notify client somehow even if have no response for him
