### PR TITLE
Introduces tcp transport and get rids of IS_SSL macro

### DIFF
--- a/src/bookish_spork_server.erl
+++ b/src/bookish_spork_server.erl
@@ -135,5 +135,5 @@ detect_transport(Options) ->
         true ->
             bookish_spork_ssl;
         _ ->
-            gen_tcp
+            bookish_spork_tcp
     end.

--- a/src/bookish_spork_ssl.erl
+++ b/src/bookish_spork_ssl.erl
@@ -8,7 +8,9 @@
     recv/2,
     send/2,
     close/1,
-    shutdown/2
+    shutdown/2,
+    setopts/2,
+    connection_information/1
 ]).
 
 -define(SSL_OPTIONS, [
@@ -50,3 +52,9 @@ close(Socket) ->
 
 shutdown(Socket, How) ->
     ssl:shutdown(Socket, How).
+
+setopts(Socket, Options) ->
+    ssl:setopts(Socket, Options).
+
+connection_information(Socket) ->
+    ssl:connection_information(Socket).

--- a/src/bookish_spork_tcp.erl
+++ b/src/bookish_spork_tcp.erl
@@ -1,0 +1,38 @@
+-module(bookish_spork_tcp).
+
+-behaviour(bookish_spork_transport).
+
+-export([
+    listen/2,
+    accept/1,
+    recv/2,
+    send/2,
+    close/1,
+    shutdown/2,
+    setopts/2,
+    connection_information/1
+]).
+
+listen(Port, Options) ->
+    gen_tcp:listen(Port, Options).
+
+accept(ListenSocket) ->
+    gen_tcp:accept(ListenSocket).
+
+recv(Socket, Length) ->
+    gen_tcp:recv(Socket, Length).
+
+send(Socket, Data) ->
+    gen_tcp:send(Socket, Data).
+
+close(Socket) ->
+    gen_tcp:close(Socket).
+
+shutdown(Socket, How) ->
+    gen_tcp:shutdown(Socket, How).
+
+setopts(Socket, Options) ->
+    inet:setopts(Socket, Options).
+
+connection_information(_Socket) ->
+    {ok, []}.


### PR DESCRIPTION
Changes:
- Introduces TCP transport module
- Get rid of `?IS_SSL` macro
- Use empty list and empty map for `ssl_info` and `ssl_ext` instead of nil/undefined when these data is not relevant

Rationale:
- The idea of having `bookish_spork_transport` behavior was to avoid this kind of macro and have any transport-specific logic in corresponding modules.
